### PR TITLE
pr810 eta

### DIFF
--- a/IBPSA/Fluid/Movers/BaseClasses/Characteristics/efficiency.mo
+++ b/IBPSA/Fluid/Movers/BaseClasses/Characteristics/efficiency.mo
@@ -7,7 +7,7 @@ function efficiency "Flow vs. efficiency characteristics for fan or pump"
   input Real d[:] "Derivatives at support points for spline interpolation";
   input Real r_N(unit="1") "Relative revolution, r_N=N/N_nominal";
   input Real delta "Small value for switching implementation around zero rpm";
-  output Real eta(unit="1", final quantity="Efficiency") "Efficiency";
+  output Modelica.SIunits.Efficiency eta "Efficiency";
 
 protected
   Integer n = size(per.V_flow, 1) "Number of data points";

--- a/IBPSA/Fluid/Movers/BaseClasses/PartialFlowMachine.mo
+++ b/IBPSA/Fluid/Movers/BaseClasses/PartialFlowMachine.mo
@@ -93,9 +93,9 @@ partial model PartialFlowMachine
   Modelica.SIunits.PressureDifference dpMachine(displayUnit="Pa")=
       -preSou.dp "Pressure difference";
 
-  Real eta(unit="1", final quantity="Efficiency") =    eff.eta "Global efficiency";
-  Real etaHyd(unit="1", final quantity="Efficiency") = eff.etaHyd "Hydraulic efficiency";
-  Real etaMot(unit="1", final quantity="Efficiency") = eff.etaMot "Motor efficiency";
+  Modelica.SIunits.Efficiency eta =    eff.eta "Global efficiency";
+  Modelica.SIunits.Efficiency etaHyd = eff.etaHyd "Hydraulic efficiency";
+  Modelica.SIunits.Efficiency etaMot = eff.etaMot "Motor efficiency";
 
   // Quantity to control
 protected


### PR DESCRIPTION
this replaces #810, sorry for two PRs

Using MSL SIunits where possible instead of defining new units should enhance readability.

Note: The MSL definition has a min value defined
```modelica
type Efficiency = Real (
      final quantity="Efficiency",
      final unit="1",
      min=0);
```

If that was the reason why the MSL unit was not used one could also change the min value at instantiation:
```modelica
Modelica.SIunits.Efficiency etaHyd(min=-1) = eff.etaHyd "Hydraulic efficiency";
```