### PR TITLE
ignore diagnostics and eventlog files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.mat
 *.mof
 buildlog.txt
+diagnostics.txt
+diagnostics_summary.txt
 dsfinal.txt
 dsin.txt
 dslog.txt
@@ -15,6 +17,7 @@ dymosim.exe
 dymosim.exp
 dymosim.lib
 empty.txt
+eventlog.txt
 failure
 help/
 modelDescription.xml


### PR DESCRIPTION
[ci skip]
Does the CI skip command also work from PRs?

The files ignored are created when using the new debugging feature,
see https://github.com/UdK-VPT/BuildingSystems/issues/78#issuecomment-349312150