### PR TITLE
added asserts in IBPSA/Fluid/Interfaces/StaticTwoPortConservationEqua…

### DIFF
--- a/IBPSA/Fluid/Interfaces/StaticTwoPortConservationEquation.mo
+++ b/IBPSA/Fluid/Interfaces/StaticTwoPortConservationEquation.mo
@@ -145,7 +145,8 @@ equation
 
   if prescribedHeatFlowRate then
     assert(noEvent( abs(Q_flow) < 200*cp_default*max(m_flow_small/1E3, abs(m_flow))),
-   "Energy may not be conserved for small mass flow rates. The implementation may require prescribedHeatFlowRate = false.");
+   "In " + getInstanceName() + ": Energy may not be conserved for small mass flow rates. 
+   The implementation may require prescribedHeatFlowRate = false.");
   end if;
 
   if allowFlowReversal then
@@ -180,7 +181,7 @@ equation
     if use_m_flowInv then
       port_b.Xi_outflow = inStream(port_a.Xi_outflow) + mXi_flow * m_flowInv;
     else // no water is added
-      assert(use_mWat_flow == false, "Wrong implementation for forward flow.");
+      assert(use_mWat_flow == false, "In " + getInstanceName() + ": Wrong implementation for forward flow.");
       port_b.Xi_outflow = inStream(port_a.Xi_outflow);
     end if;
 
@@ -189,7 +190,7 @@ equation
       if use_m_flowInv then
         port_a.Xi_outflow = inStream(port_b.Xi_outflow) - mXi_flow * m_flowInv;
       else // no water added
-        assert(use_mWat_flow == false, "Wrong implementation for reverse flow.");
+        assert(use_mWat_flow == false, "In " + getInstanceName() + ": Wrong implementation for reverse flow.");
         port_a.Xi_outflow = inStream(port_b.Xi_outflow);
       end if;
     else // no  flow reversal
@@ -226,7 +227,7 @@ equation
   if use_m_flowInv and use_C_flow then
     port_b.C_outflow =  inStream(port_a.C_outflow) + C_flow_internal * m_flowInv;
   else // no trace substance added.
-    assert(not use_C_flow, "Wrong implementation of trace substance balance for forward flow.");
+    assert(not use_C_flow, "In " + getInstanceName() + ": Wrong implementation of trace substance balance for forward flow.");
     port_b.C_outflow =  inStream(port_a.C_outflow);
   end if;
 
@@ -331,6 +332,12 @@ IBPSA.Fluid.Interfaces.ConservationEquation</a>.
 </html>",
 revisions="<html>
 <ul>
+<li>
+March 30, 2018, by Filip Jorissen:<br/>
+Added <code>getInstanceName()</code> in asserts to facilitate
+debugging.<br/>
+See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/901\">#901</a>.
+</li>
 <li>
 April 24, 2017, by Michael Wetter and Filip Jorissen:<br/>
 Reimplemented check for energy conversion.<br/>


### PR DESCRIPTION
…tion.mo for #901 

This produces error messages like:

```
In test.hea2.vol.steBal: Energy may not be conserved for small mass flow rates. 
   The implementation may require prescribedHeatFlowRate = false.
```