### PR TITLE
Removed unicode character for #988

### DIFF
--- a/IBPSA/Fluid/FixedResistances/Validation/PlugFlowPipes/PlugFlowULg.mo
+++ b/IBPSA/Fluid/FixedResistances/Validation/PlugFlowPipes/PlugFlowULg.mo
@@ -1,4 +1,4 @@
-﻿within IBPSA.Fluid.FixedResistances.Validation.PlugFlowPipes;
+within IBPSA.Fluid.FixedResistances.Validation.PlugFlowPipes;
 model PlugFlowULg "Validation against data from Université de Liège"
   extends Modelica.Icons.Example;
   package Medium = IBPSA.Media.Water;

--- a/IBPSA/package.mo
+++ b/IBPSA/package.mo
@@ -1,4 +1,4 @@
-﻿within ;
+within ;
 package IBPSA "Library with models for building energy and control systems"
   extends Modelica.Icons.Package;
 


### PR DESCRIPTION
This closes #988. (Note that the diff in github won't show the removed character.) On a console, the change is
```bash
$ git diff origin/master
diff --git a/IBPSA/Fluid/FixedResistances/Validation/PlugFlowPipes/PlugFlowULg.mo b/IBPSA/Fluid/FixedResistances/Validation/PlugFlowPipes/PlugFlowULg.mo
index b538a07a..a1d4d92c 100644
--- a/IBPSA/Fluid/FixedResistances/Validation/PlugFlowPipes/PlugFlowULg.mo
+++ b/IBPSA/Fluid/FixedResistances/Validation/PlugFlowPipes/PlugFlowULg.mo
@@ -1,4 +1,4 @@
-<U+FEFF>within IBPSA.Fluid.FixedResistances.Validation.PlugFlowPipes;
+within IBPSA.Fluid.FixedResistances.Validation.PlugFlowPipes;
 model PlugFlowULg "Validation against data from Université de Liège"
   extends Modelica.Icons.Example;
   package Medium = IBPSA.Media.Water;
diff --git a/IBPSA/package.mo b/IBPSA/package.mo
index a69ca8a1..d97e1c3e 100644
--- a/IBPSA/package.mo
+++ b/IBPSA/package.mo
@@ -1,4 +1,4 @@
-<U+FEFF>within ;
+within ;
 package IBPSA "Library with models for building energy and control systems"
   extends Modelica.Icons.Package;
```