### PR TITLE
Set allowFlowReversal to true. For #937

### DIFF
--- a/IBPSA/Airflow/Multizone/BaseClasses/TwoWayFlowElement.mo
+++ b/IBPSA/Airflow/Multizone/BaseClasses/TwoWayFlowElement.mo
@@ -3,8 +3,8 @@ partial model TwoWayFlowElement "Flow resistance that uses the power law"
   extends IBPSA.Fluid.Interfaces.PartialFourPortInterface(
     redeclare final package Medium1 = Medium,
     redeclare final package Medium2 = Medium,
-    final allowFlowReversal1=false,
-    final allowFlowReversal2=false,
+    final allowFlowReversal1=true,
+    final allowFlowReversal2=true,
     final m1_flow_nominal=10/3600*1.2,
     final m2_flow_nominal=m1_flow_nominal);
   extends IBPSA.Airflow.Multizone.BaseClasses.ErrorControl;
@@ -130,6 +130,17 @@ for doors that can be open or closed as a function of an input signal.
 </html>",
 revisions="<html>
 <ul>
+<li>
+September 13, 2018, by Michael Wetter:<br/>
+Set <code>allowFlowReversal=true</code> as the flow can be slightly negative
+due to the regularization, in which case the <code>m_flow(min=0)</code>
+that is set in the base class
+<a href=\"modelica://IBPSA.Fluid.Interfaces.PartialFourPort\">
+IBPSA.Fluid.Interfaces.PartialFourPort</a>
+is violated.<br/>
+See
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/937\">#937</a>.
+</li>
 <li>
 November 3, 2016, by Michael Wetter:<br/>
 Removed start values for inflowing density


### PR DESCRIPTION
This corrects the min=0 violation discussed in https://github.com/ibpsa/modelica-ibpsa/issues/937#issuecomment-421066013
