### PR TITLE
Fix warnings

### DIFF
--- a/IBPSA/Resources/C-Sources/fileWriterStructure.h
+++ b/IBPSA/Resources/C-Sources/fileWriterStructure.h
@@ -5,7 +5,7 @@
 #ifndef IBPSA_FILEWRITERStructure_h /* Not needed since it is only a typedef; added for safety */
 #define IBPSA_FILEWRITERStructure_h
 
-static const char** FileWriterNames; /* Array with pointers to all file names */
+static char** FileWriterNames; /* Array with pointers to all file names */
 static unsigned int FileWriterNames_n = 0;     /* Number of files */
 
 typedef struct FileWriter {


### PR DESCRIPTION
Fix MSVC compiler warning on different constness in arguments for strcpy or realloc