### PR TITLE
replaced getline with fscanf #1136

### DIFF
--- a/IBPSA/Resources/C-Sources/getTimeSpan.c
+++ b/IBPSA/Resources/C-Sources/getTimeSpan.c
@@ -135,21 +135,21 @@ int getTimeSpan(const char * fileName, const char * tabName, double* timeSpan) {
 
   /* find first time stamp */
   retVal = sscanf(line, "%lf", &firstTimeStamp);
-  free(line); /* free allocated memory */
   if (retVal == EOF){
     ModelicaFormatError("Received unexpected EOF in getTimeSpan.c when searching for first time stamp in %s.",
     fileName);
   }
+  free(line); /* free allocated memory */
 
   /* scan to file end, to find the last time stamp */
   tempInd = rowIndex;
   while (rowIndex < (rowCount+tempInd-2)) {
-    fscanf(fp, "%*[^\n]\n", NULL);
+    line = searchLine(length, fp); /* move to the end of each line */
+    free(line);
     rowIndex++;
   }
 
   retVal = fscanf(fp, "%lf", &lastTimeStamp);
-
   if (retVal == EOF){
     ModelicaFormatError("Received unexpected EOF in getTimeSpan.c when searching last time stamp in %s.",
     fileName);

--- a/IBPSA/Resources/C-Sources/getTimeSpan.c
+++ b/IBPSA/Resources/C-Sources/getTimeSpan.c
@@ -28,7 +28,7 @@ char *concat(const char *s1, const char *s2) {
   const size_t len2 = strlen(s2);
   char *result = malloc(len1 + len2 + 1);
   if (result == NULL){
-	  ModelicaError("Failed to allocate memory in getTimeSpan.c");
+    ModelicaError("Failed to allocate memory in getTimeSpan.c");
   }
   strcpy(result, s1);
   strcat(result, s2);
@@ -47,26 +47,26 @@ char *concat(const char *s1, const char *s2) {
  * 	returns: entire line string
  */
 char *searchLine(int length, FILE *fp) {
-	char *tempLine = (char *)malloc(length*sizeof(char));
-	char *line = (char *)malloc(length*sizeof(char));
-	if (line == NULL || tempLine == NULL) {
-		ModelicaError("Failed to allocate memory in getTimeSpan.c");
-	}
-	int loop = 0;
-	while (fgets(tempLine, length, fp)) {
-		loop++;
-		line = (char *)realloc(line, loop*length*sizeof(char));
-		if (line == NULL) {
-			ModelicaError("Failed to allocate memory in getTimeSpan.c");
-		}
-		line = concat(line, tempLine);
-		if (strstr(tempLine, "\n")) {
-			break;
-		}
-	}
-	free(tempLine);
+  char *tempLine = (char *)malloc(length*sizeof(char));
+  char *line = (char *)malloc(length*sizeof(char));
+  if (line == NULL || tempLine == NULL) {
+    ModelicaError("Failed to allocate memory in getTimeSpan.c");
+  }
+  int loop = 0;
+  while (fgets(tempLine, length, fp)) {
+    loop++;
+    line = (char *)realloc(line, loop*length*sizeof(char));
+    if (line == NULL) {
+      ModelicaError("Failed to allocate memory in getTimeSpan.c");
+    }
+    line = concat(line, tempLine);
+    if (strstr(tempLine, "\n")) {
+      break;
+    }
+  }
+  free(tempLine);
 
-	return line;
+  return line;
 }
 
 /*
@@ -103,8 +103,8 @@ int getTimeSpan(const char * fileName, const char * tabName, double* timeSpan) {
   while (1) {
     rowIndex++;
     if (fscanf(fp, formatString, &rowCount, &columnCount) == 2) {
-    	line = searchLine(length, fp); /* finish reading current line */
-    	break;
+      line = searchLine(length, fp); /* finish reading current line */
+      break;
     }
   }
   free(formatString);
@@ -114,8 +114,8 @@ int getTimeSpan(const char * fileName, const char * tabName, double* timeSpan) {
 
    /* find the end of file head */
   while(strstr(line,"#")) {
-	  line = searchLine(length, fp);
-	  rowIndex++;
+    line = searchLine(length, fp);
+    rowIndex++;
   }
 
   /* find first time stamp */

--- a/IBPSA/Resources/C-Sources/getTimeSpan.c
+++ b/IBPSA/Resources/C-Sources/getTimeSpan.c
@@ -50,6 +50,7 @@ char *searchLine(int length, FILE *fp) {
   int loop = 0;
   char *tempLine;
   char *line;
+  char *oldLine;
 
   tempLine = (char *)malloc(length*sizeof(char));
   if (tempLine == NULL) {
@@ -68,7 +69,9 @@ char *searchLine(int length, FILE *fp) {
       ModelicaError("Failed to allocate memory in getTimeSpan.c");
     }
     /* concatenate new reading to old reading */
-    line = concat(line, tempLine);
+    oldLine = line;
+    line = concat(oldLine, tempLine);
+    free(oldLine);
     /* check if end-of-line is achieved */
     if (strstr(tempLine, "\n")) {
       break;

--- a/IBPSA/Resources/C-Sources/getTimeSpan.c
+++ b/IBPSA/Resources/C-Sources/getTimeSpan.c
@@ -38,13 +38,13 @@ char *concat(const char *s1, const char *s2) {
 /*
  * Function: searchLine
  * --------------------
- * 	Output an entire line in file. This function calls malloc and hence
- * 	the caller must call free when the return string is no longer used.
+ *  Output an entire line in file. This function calls malloc and hence
+ *  the caller must call free when the return string is no longer used.
  *
- * 	length: maximum length of each read done by fgets()
- * 	fp: pointer to the FILE object
+ *  length: maximum length of each read done by fgets()
+ *  fp: pointer to the FILE object
  *
- * 	returns: entire line string
+ *  returns: entire line string
  */
 char *searchLine(int length, FILE *fp) {
   char *tempLine = (char *)malloc(length*sizeof(char));

--- a/IBPSA/Resources/C-Sources/getTimeSpan.c
+++ b/IBPSA/Resources/C-Sources/getTimeSpan.c
@@ -50,6 +50,7 @@ char *searchLine(int length, FILE *fp) {
   int loop = 0;
   char *tempLine;
   char *line;
+
   tempLine = (char *)malloc(length*sizeof(char));
   if (tempLine == NULL) {
     ModelicaError("Failed to allocate memory in getTimeSpan.c");
@@ -58,6 +59,7 @@ char *searchLine(int length, FILE *fp) {
   if (line == NULL) {
     ModelicaError("Failed to allocate memory in getTimeSpan.c");
   }
+
   while (fgets(tempLine, length, fp)) {
     loop++;
     /* reallocate memory for line, to ensure enough space to concatenate new reading */
@@ -67,6 +69,7 @@ char *searchLine(int length, FILE *fp) {
     }
     /* concatenate new reading to old reading */
     line = concat(line, tempLine);
+    /* check if end-of-line is achieved */
     if (strstr(tempLine, "\n")) {
       break;
     }
@@ -120,7 +123,7 @@ int getTimeSpan(const char * fileName, const char * tabName, double* timeSpan) {
   line = searchLine(length, fp); /* read next line */
   rowIndex++;
 
-   /* find the end of file head */
+  /* find the end of file head */
   while(strstr(line, "#")) {
     free(line); /* free allocated memory */
     line = searchLine(length, fp);

--- a/IBPSA/Resources/C-Sources/getTimeSpan.c
+++ b/IBPSA/Resources/C-Sources/getTimeSpan.c
@@ -46,7 +46,6 @@ char *concat(const char *s1, const char *s2) {
  *
  * 	returns: entire line string
  */
-
 char *searchLine(int length, FILE *fp) {
 	char *tempLine = (char *)malloc(length*sizeof(char));
 	char *line = (char *)malloc(length*sizeof(char));


### PR DESCRIPTION
The alternative of `getline()` function include function `fscanf()` and `fgets()`. However, both of them requires to specify the object with length, to store the result:
```
int fscanf ( FILE * stream, const char * format, ... ); ...
The additional arguments should point to already allocated objects ...
```
```
char * fgets ( char * str, int num, FILE * stream );
```

`fscanf()` is used here since it is relatively safe to specify the maximum length of the first section (before first empty space) of each line.