### PR TITLE
Removed duplicate connector for #1248

### DIFF
--- a/IBPSA/Fluid/Sources/BaseClasses/Outside.mo
+++ b/IBPSA/Fluid/Sources/BaseClasses/Outside.mo
@@ -25,17 +25,8 @@ protected
   IBPSA.Utilities.Psychrometrics.X_pTphi x_pTphi if
        not singleSubstance "Block to compute water vapor concentration";
 
-  Modelica.Blocks.Interfaces.RealInput X_in_internal[Medium.nX](
-    each final unit="kg/kg",
-    final quantity=Medium.substanceNames)
-    "Needed to connect to conditional connector";
   Modelica.Blocks.Interfaces.RealInput T_in_internal(final unit="K",
                                                      displayUnit="degC")
-    "Needed to connect to conditional connector";
-  Modelica.Blocks.Interfaces.RealInput p_in_internal(final unit="Pa")
-    "Needed to connect to conditional connector";
-  Modelica.Blocks.Interfaces.RealInput C_in_internal[Medium.nC](
-       quantity=Medium.extraPropertiesNames)
     "Needed to connect to conditional connector";
   Modelica.Blocks.Interfaces.RealInput h_internal = Medium.specificEnthalpy(
     Medium.setState_pTX(p_in_internal, T_in_internal, X_in_internal));
@@ -132,9 +123,15 @@ with exception of boundary pressure, do not have an effect.
 revisions="<html>
 <ul>
 <li>
+November 14, 2019, by Michael Wetter:<br/>
+Removed duplicate connector.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1248\"> #1248</a>.
+</li>
+<li>
 January 14, 2019 by Jianjun Hu:<br/>
 Changed to extend <a href=\"modelica://IBPSA.Fluid.Sources.BaseClasses.PartialSource\">
-IBPSA.Fluid.Sources.BaseClasses.PartialSource</a>. This is for 
+IBPSA.Fluid.Sources.BaseClasses.PartialSource</a>. This is for
 <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1050\"> #1050</a>.
 </li>
 <li>

--- a/IBPSA/Fluid/Sources/MassFlowSource_WeatherData.mo
+++ b/IBPSA/Fluid/Sources/MassFlowSource_WeatherData.mo
@@ -50,13 +50,6 @@ protected
   Modelica.Blocks.Interfaces.RealInput h_in_internal(
     final unit="J/kg")
     "Needed to connect to conditional connector";
-  Modelica.Blocks.Interfaces.RealOutput X_in_internal[Medium.nX](
-    each final unit = "kg/kg",
-    final quantity=Medium.substanceNames)
-    "Needed to connect to conditional connector";
-  Modelica.Blocks.Interfaces.RealOutput C_in_internal[Medium.nC](
-    final quantity=Medium.extraPropertiesNames)
-    "Needed to connect to conditional connector";
 
 equation
   Modelica.Fluid.Utilities.checkBoundary(
@@ -194,9 +187,15 @@ with exception of boundary flow rate, do not have an effect.
 revisions="<html>
 <ul>
 <li>
+November 14, 2019, by Michael Wetter:<br/>
+Removed duplicate connector.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1248\"> #1248</a>.
+</li>
+<li>
 January 14, 2019 by Jianjun Hu:<br/>
 Changed to extend <a href=\"modelica://IBPSA.Fluid.Sources.BaseClasses.PartialSource\">
-IBPSA.Fluid.Sources.BaseClasses.PartialSource</a>. This is for 
+IBPSA.Fluid.Sources.BaseClasses.PartialSource</a>. This is for
 <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1050\"> #1050</a>.
 </li>
 <li>


### PR DESCRIPTION
This closes #1248
This is simply a clean-up to avoid a warning as the connectors are already declared in the base class.