### PR TITLE
Incompatible sizes for variables ROM

### DIFF
--- a/IBPSA/ThermalZones/ReducedOrder/RC/FourElements.mo
+++ b/IBPSA/ThermalZones/ReducedOrder/RC/FourElements.mo
@@ -198,6 +198,11 @@ equation
   Documentation(revisions="<html>
   <ul>
   <li>
+  December 9, 2019, by Moritz Lauster:<br/>
+  Changes <code>nExt</code> to <code>nRoof</code> for
+  <code>RRoof</code> and <code>CRoof</code>
+  </li>
+  <li>
   July 11, 2019, by Katharina Brinkmann:<br/>
   Renamed <code>alphaRoof</code> to <code>hConRoof</code>,
   <code>alphaRoofConst</code> to <code>hConRoof_const</code>

--- a/IBPSA/ThermalZones/ReducedOrder/RC/FourElements.mo
+++ b/IBPSA/ThermalZones/ReducedOrder/RC/FourElements.mo
@@ -10,7 +10,7 @@ model FourElements "Thermal Zone with four elements for exterior walls,
     annotation(Dialog(group="Roof"));
   parameter Integer nRoof(min = 1) "Number of RC-elements of roof"
     annotation(Dialog(group="Roof"));
-  parameter Modelica.SIunits.ThermalResistance RRoof[nExt](
+  parameter Modelica.SIunits.ThermalResistance RRoof[nRoof](
     each min=Modelica.Constants.small)
     "Vector of resistances of roof, from inside to outside"
     annotation(Dialog(group="Roof"));
@@ -18,7 +18,7 @@ model FourElements "Thermal Zone with four elements for exterior walls,
     min=Modelica.Constants.small)
     "Resistance of remaining resistor RRoofRem between capacity n and outside"
     annotation(Dialog(group="Roof"));
-  parameter Modelica.SIunits.HeatCapacity CRoof[nExt](
+  parameter Modelica.SIunits.HeatCapacity CRoof[nRoof](
     each min=Modelica.Constants.small)
     "Vector of heat capacities of roof, from inside to outside"
     annotation(Dialog(group="Roof"));

--- a/IBPSA/ThermalZones/ReducedOrder/RC/ThreeElements.mo
+++ b/IBPSA/ThermalZones/ReducedOrder/RC/ThreeElements.mo
@@ -10,7 +10,7 @@ model ThreeElements "Thermal Zone with three elements for exterior walls,
     annotation(Dialog(group="Floor plate"));
   parameter Integer nFloor(min = 1) "Number of RC-elements of floor plate"
     annotation(Dialog(group="Floor plate"));
-  parameter Modelica.SIunits.ThermalResistance RFloor[nExt](
+  parameter Modelica.SIunits.ThermalResistance RFloor[nFloor](
     each min=Modelica.Constants.small)
     "Vector of resistances of floor plate, from inside to outside"
     annotation(Dialog(group="Floor plate"));
@@ -18,7 +18,7 @@ model ThreeElements "Thermal Zone with three elements for exterior walls,
     min=Modelica.Constants.small)
     "Resistance of remaining resistor RFloorRem between capacity n and outside"
     annotation(Dialog(group="Floor plate"));
-  parameter Modelica.SIunits.HeatCapacity CFloor[nExt](
+  parameter Modelica.SIunits.HeatCapacity CFloor[nFLoor](
     each min=Modelica.Constants.small)
     "Vector of heat capacities of floor plate, from inside to outside"
     annotation(Dialog(group="Floor plate"));
@@ -183,7 +183,7 @@ equation
   <ul>
   <li>
   July 11, 2019, by Katharina Brinkmann:<br/>
-  Renamed <code>alphaFloor</code> to <code>hConFloor</code>, 
+  Renamed <code>alphaFloor</code> to <code>hConFloor</code>,
   <code>alphaFloorConst</code> to <code>hConFloor_const</code>
   </li>
   <li>

--- a/IBPSA/ThermalZones/ReducedOrder/RC/ThreeElements.mo
+++ b/IBPSA/ThermalZones/ReducedOrder/RC/ThreeElements.mo
@@ -182,6 +182,11 @@ equation
     Documentation(revisions="<html>
   <ul>
   <li>
+  December 9, 2019, by Moritz Lauster:<br/>
+  Changes <code>nExt</code> to <code>nFloor</code> for
+  <code>RFloor</code> and <code>CFloor</code>
+  </li>
+  <li>
   July 11, 2019, by Katharina Brinkmann:<br/>
   Renamed <code>alphaFloor</code> to <code>hConFloor</code>,
   <code>alphaFloorConst</code> to <code>hConFloor_const</code>

--- a/IBPSA/ThermalZones/ReducedOrder/RC/ThreeElements.mo
+++ b/IBPSA/ThermalZones/ReducedOrder/RC/ThreeElements.mo
@@ -18,7 +18,7 @@ model ThreeElements "Thermal Zone with three elements for exterior walls,
     min=Modelica.Constants.small)
     "Resistance of remaining resistor RFloorRem between capacity n and outside"
     annotation(Dialog(group="Floor plate"));
-  parameter Modelica.SIunits.HeatCapacity CFloor[nFLoor](
+  parameter Modelica.SIunits.HeatCapacity CFloor[nFloor](
     each min=Modelica.Constants.small)
     "Vector of heat capacities of floor plate, from inside to outside"
     annotation(Dialog(group="Floor plate"));


### PR DESCRIPTION
This Closes #1258 
This changes `nExt` to `nFloor` and `nRoof` for `RFloor` and `CFloor` resp. `RRoof` and `CRoof`.
@LXUtue, please check if this fixes your problems.
@mwetter, please check if models still compile correctly, I unfortunately don't have any Dymola or JModelica installtion at hand.

Thanks! 