### PR TITLE
Set m_flow_small to final

### DIFF
--- a/IBPSA/Airflow/Multizone/BaseClasses/PowerLawResistance.mo
+++ b/IBPSA/Airflow/Multizone/BaseClasses/PowerLawResistance.mo
@@ -2,7 +2,8 @@ within IBPSA.Airflow.Multizone.BaseClasses;
 partial model PowerLawResistance "Flow resistance that uses the power law"
   extends IBPSA.Fluid.Interfaces.PartialTwoPortInterface(
     final allowFlowReversal=true,
-    final m_flow_nominal=rho_default*k*dp_turbulent);
+    final m_flow_nominal=rho_default*k*dp_turbulent,
+    final m_flow_small=1E-4*abs(m_flow_nominal));
   extends IBPSA.Airflow.Multizone.BaseClasses.ErrorControl;
 
   constant Boolean homotopyInitialization = true "= true, use homotopy method"
@@ -131,6 +132,12 @@ The model is used as a base for the interzonal air flow models.
 </html>",
 revisions="<html>
 <ul>
+<li>
+May 12, 2020, by Michael Wetter:<br/>
+Changed assignment of <code>m_flow_small</code> to <code>final</code>.
+This quantity are not used in this model and models that extend from it.
+Hence there is no need for the user to change the value.
+</li>
 <li>
 April 14, 2020, by Michael Wetter:<br/>
 Changed <code>homotopyInitialization</code> to a constant.<br/>

--- a/IBPSA/Airflow/Multizone/BaseClasses/TwoWayFlowElement.mo
+++ b/IBPSA/Airflow/Multizone/BaseClasses/TwoWayFlowElement.mo
@@ -6,7 +6,9 @@ partial model TwoWayFlowElement "Flow resistance that uses the power law"
     final allowFlowReversal1=true,
     final allowFlowReversal2=true,
     final m1_flow_nominal=10/3600*1.2,
-    final m2_flow_nominal=m1_flow_nominal);
+    final m2_flow_nominal=m1_flow_nominal,
+    final m1_flow_small=1E-4*abs(m1_flow_nominal),
+    final m2_flow_small=1E-4*abs(m2_flow_nominal));
   extends IBPSA.Airflow.Multizone.BaseClasses.ErrorControl;
 
   replaceable package Medium =
@@ -132,6 +134,13 @@ for doors that can be open or closed as a function of an input signal.
 </html>",
 revisions="<html>
 <ul>
+<li>
+May 12, 2020, by Michael Wetter:<br/>
+Changed assignment of <code>m1_flow_small</code> and
+<code>m2_flow_small</code> to <code>final</code>.
+These quantities are not used in this model and models that extend from it.
+Hence there is no need for the user to change the value.
+</li>
 <li>
 January 18, 2019, by Jianjun Hu:<br/>
 Limited the media choice to moist air only.

--- a/IBPSA/Airflow/Multizone/BaseClasses/ZonalFlow.mo
+++ b/IBPSA/Airflow/Multizone/BaseClasses/ZonalFlow.mo
@@ -1,12 +1,14 @@
 within IBPSA.Airflow.Multizone.BaseClasses;
 partial model ZonalFlow "Flow across zonal boundaries of a room"
   extends IBPSA.Fluid.Interfaces.PartialFourPortInterface(
-     redeclare final package Medium1 = Medium,
-     redeclare final package Medium2 = Medium,
-     final allowFlowReversal1 = false,
-     final allowFlowReversal2 = false,
-     final m1_flow_nominal = 10/3600*1.2,
-     final m2_flow_nominal = m1_flow_nominal);
+    redeclare final package Medium1 = Medium,
+    redeclare final package Medium2 = Medium,
+    final allowFlowReversal1 = false,
+    final allowFlowReversal2 = false,
+    final m1_flow_nominal = 10/3600*1.2,
+    final m2_flow_nominal = m1_flow_nominal,
+    final m1_flow_small=1E-4*abs(m1_flow_nominal),
+    final m2_flow_small=1E-4*abs(m2_flow_nominal));
 
    replaceable package Medium = Modelica.Media.Interfaces.PartialMedium
     annotation (choices(
@@ -69,6 +71,13 @@ Models that extend this model need to provide an equation for
 </html>",
 revisions="<html>
 <ul>
+<li>
+May 12, 2020, by Michael Wetter:<br/>
+Changed assignment of <code>m1_flow_small</code> and
+<code>m2_flow_small</code> to <code>final</code>.
+These quantities are not used in this model and models that extend from it.
+Hence there is no need for the user to change the value.
+</li>
 <li>
 January 18, 2019, by Jianjun Hu:<br/>
 Limited the media choice to moist air only.

--- a/IBPSA/Resources/Scripts/Dymola/ConvertIBPSA_from_3.0_to_4.0.mos
+++ b/IBPSA/Resources/Scripts/Dymola/ConvertIBPSA_from_3.0_to_4.0.mos
@@ -5,6 +5,16 @@ clear
 
 convertClear();
 
+// Conversion for https://github.com/ibpsa/modelica-ibpsa/issues/1362
+convertModifiers("IBPSA.Airflow.Multizone.BaseClasses.PowerLawResistance", {"m_flow_small"}, fill("",0), true);
+convertModifiers("IBPSA.Airflow.Multizone.BaseClasses.TwoWayFlowElement", {"m1_flow_small", "m2_flow_small"}, fill("",0), true);
+convertModifiers("IBPSA.Airflow.Multizone.EffectiveAirLeakageArea", {"m_flow_small"}, fill("",0), true);
+convertModifiers("IBPSA.Airflow.Multizone.Orifice", {"m_flow_small"}, fill("",0), true);
+convertModifiers("IBPSA.Airflow.Multizone.DoorDiscretizedOpen", {"m1_flow_small", "m2_flow_small"}, fill("",0), true);
+convertModifiers("IBPSA.Airflow.Multizone.DoorDiscretizedOperable", {"m1_flow_small", "m2_flow_small"}, fill("",0), true);
+convertModifiers("IBPSA.Airflow.Multizone.ZonalFlow_ACS", {"m1_flow_small", "m2_flow_small"}, fill("",0), true);
+convertModifiers("IBPSA.Airflow.Multizone.ZonalFlow_m_flow", {"m1_flow_small", "m2_flow_small"}, fill("",0), true);
+
 convertClass("IBPSA.Fluid.Sources.FixedBoundary",
              "IBPSA.Obsolete.Fluid.Sources.FixedBoundary");
 convertClass("IBPSA.Controls.SetPoints.HotWaterTemperatureReset",


### PR DESCRIPTION
This closes #1362.

The entries for the conversion script are
```
convertModifiers("IBPSA.Airflow.Multizone.BaseClasses.PowerLawResistance", {"m_flow_small"}, fill("",0), true);
convertModifiers("IBPSA.Airflow.Multizone.BaseClasses.TwoWayFlowElement", {"m1_flow_small", "m2_flow_small"}, fill("",0), true);
convertModifiers("IBPSA.Airflow.Multizone.EffectiveAirLeakageArea", {"m_flow_small"}, fill("",0), true);
convertModifiers("IBPSA.Airflow.Multizone.Orifice", {"m_flow_small"}, fill("",0), true);
convertModifiers("IBPSA.Airflow.Multizone.DoorDiscretizedOpen", {"m1_flow_small", "m2_flow_small"}, fill("",0), true);
convertModifiers("IBPSA.Airflow.Multizone.DoorDiscretizedOperable", {"m1_flow_small", "m2_flow_small"}, fill("",0), true);
convertModifiers("IBPSA.Airflow.Multizone.ZonalFlow_ACS", {"m1_flow_small", "m2_flow_small"}, fill("",0), true);
convertModifiers("IBPSA.Airflow.Multizone.ZonalFlow_m_flow", {"m1_flow_small", "m2_flow_small"}, fill("",0), true);
```