### PR TITLE
Issue1365 pid reverse action

### DIFF
--- a/IBPSA/Controls/Continuous/Examples/LimPID.mo
+++ b/IBPSA/Controls/Continuous/Examples/LimPID.mo
@@ -14,7 +14,7 @@ model LimPID "Test model for PID controller with optional reverse action"
           annotation (Placement(transformation(extent={{-20,30},{0,50}})));
   IBPSA.Controls.Continuous.LimPID limPIDRev(
     controllerType=Modelica.Blocks.Types.SimpleController.PID,
-    reverseAction=true,
+    reverseActing=false,
     Ti=1,
     Td=1,
     yMax=1,

--- a/IBPSA/Controls/Continuous/Examples/LimPIDWithReset.mo
+++ b/IBPSA/Controls/Continuous/Examples/LimPIDWithReset.mo
@@ -130,7 +130,6 @@ First implementation.
       final reset=reset,
       yMax=1,
       yMin=0,
-      controllerType=Modelica.Blocks.Types.SimpleController.PI,
       Ti=1,
       k=10) "PI controller"
       annotation (Placement(transformation(extent={{-10,-10},{10,10}})));

--- a/IBPSA/Controls/Continuous/Examples/PIDHysteresis.mo
+++ b/IBPSA/Controls/Continuous/Examples/PIDHysteresis.mo
@@ -4,7 +4,6 @@ model PIDHysteresis "Example model for PID controller with hysteresis"
 
   IBPSA.Controls.Continuous.PIDHysteresis con(
     pre_y_start=false,
-    controllerType=Modelica.Blocks.Types.SimpleController.PI,
     yMin=0.3,
     Ti=600,
     Td=60)

--- a/IBPSA/Controls/Continuous/Examples/PIDHysteresisTimer.mo
+++ b/IBPSA/Controls/Continuous/Examples/PIDHysteresisTimer.mo
@@ -6,7 +6,6 @@ model PIDHysteresisTimer
   IBPSA.Controls.Continuous.PIDHysteresisTimer con(
     yMin=0.3,
     minOffTime=10000,
-    controllerType=Modelica.Blocks.Types.SimpleController.PI,
     Ti=60,
     Td=10)
     annotation (Placement(transformation(extent={{-40,20},{-20,40}})));

--- a/IBPSA/Controls/Continuous/LimPID.mo
+++ b/IBPSA/Controls/Continuous/LimPID.mo
@@ -7,7 +7,7 @@ block LimPID
     "Control error (set point - measurement)";
 
   parameter Modelica.Blocks.Types.SimpleController controllerType=
-         Modelica.Blocks.Types.SimpleController.PID "Type of controller";
+         Modelica.Blocks.Types.SimpleController.PI "Type of controller";
   parameter Real k(min=0) = 1 "Gain of controller";
   parameter Modelica.SIunits.Time Ti(min=Modelica.Constants.small)=0.5
     "Time constant of Integrator block" annotation (Dialog(enable=
@@ -55,8 +55,8 @@ block LimPID
   parameter Boolean strict=true "= true, if strict limits with noEvent(..)"
     annotation (Evaluate=true, choices(checkBox=true), Dialog(tab="Advanced"));
 
-  parameter Boolean reverseAction = false
-    "Set to true for throttling the water flow rate through a cooling coil controller";
+  parameter Boolean reverseActing = true
+    "Set to true for reverse acting, or false for direct acting control action";
 
   parameter IBPSA.Types.Reset reset = IBPSA.Types.Reset.Disabled
     "Type of controller output reset"
@@ -127,8 +127,8 @@ block LimPID
 protected
   constant Modelica.SIunits.Time unitTime=1 annotation (HideResult=true);
 
-  final parameter Real revAct = if reverseAction then -1 else 1
-    "Switch for sign for reverse action";
+  final parameter Real revAct = if reverse then 1 else -1
+    "Switch for sign for reverse or direct acting controller";
 
   parameter Boolean with_I = controllerType==Modelica.Blocks.Types.SimpleController.PI or
                              controllerType==Modelica.Blocks.Types.SimpleController.PID
@@ -353,29 +353,57 @@ equation
 defaultComponentName="conPID",
 Documentation(info="<html>
 <p>
-This model is similar to
-<a href=\"modelica://Modelica.Blocks.Continuous.LimPID\">Modelica.Blocks.Continuous.LimPID</a>,
-except for the following changes:
+PID controller in the standard form
 </p>
-
-<ol>
-<li>
+<p align=\"center\" style=\"font-style:italic;\">
+y = k &nbsp; ( e(t) + 1 &frasl; T<sub>i</sub> &nbsp; &int; e(s) ds + T<sub>d</sub> de(t)&frasl;dt ),
+</p>
 <p>
-It can be configured to have a reverse action.
+where
+<i>y</i> is the control signal,
+<i>e(t) = u<sub>s</sub> - u<sub>m</sub></i> is the control error,
+with <i>u<sub>s</sub></i> being the set point and <i>u<sub>m</sub></i> being
+the measured quantity,
+<i>k</i> is the gain,
+<i>T<sub>i</sub></i> is the time constant of the integral term and
+<i>T<sub>d</sub></i> is the time constant of the derivative term.
 </p>
-<p>If the parameter <code>reverseAction=false</code> (the default), then
-<code>u_m &lt; u_s</code> increases the controller output,
-otherwise the controller output is decreased. Thus,
+<p>
+Note that the units of <i>k</i> are the inverse of the units of the control error,
+while the units of <i>T<sub>i</sub></i> and <i>T<sub>d</sub></i> are seconds.
+</p>
+<p>
+For detailed treatment of integrator anti-windup, set-point weights and output limitation, see
+<a href=\"modelica://Modelica.Blocks.Continuous.LimPID\">Modelica.Blocks.Continuous.LimPID</a>.
+</p>
+<h4>Options</h4>
+This controller can be configured as follows.
+<h5>P, PI, PD, or PID action</h5>
+<p>
+Through the parameter <code>controllerType</code>, the controller can be configured
+as P, PI, PD or PID controller. The default configuration is PI.
+</p>
+<h5>Direct or reverse acting</h5>
+<p>
+Through the parameter <code>reverseActing</code>, the controller can be configured to
+be reverse or direct acting.
+The standard form is reverse acting, which is the default configuration.
+For a reverse acting controller, for a constant set point,
+an increase in measurement signal <code>u_m</code> decreases the control output signal <code>y</code>
+(Montgomery and McDowall, 2008).
+Thus,
 </p>
 <ul>
-  <li>for a heating coil with a two-way valve, set <code>reverseAction = false</code>, </li>
-  <li>for a cooling coils with a two-way valve, set <code>reverseAction = true</code>. </li>
+  <li>
+  for a heating coil with a two-way valve, leave <code>reverseActing = true</code>, but
+  </li>
+  <li>
+  for a cooling coil with a two-way valve, set <code>reverseActing = false</code>.
+  </li>
 </ul>
-</li>
-
-<li>
+<h5>Reset of the controller output</h5>
 <p>
-It can be configured to enable an input port that allows resetting the controller
+The controller can be configured to enable an input port that allows resetting the controller
 output. The controller output can be reset as follows:
 </p>
 <ul>
@@ -392,35 +420,41 @@ output. The controller output can be reset as follows:
   </li>
   <li>
   If <code>reset = IBPSA.Types.Reset.Input</code>, then a boolean
-  input signal <code>trigger</code> is enabled. Whenever the value of
-  this input changes from <code>false</code> to <code>true</code>,
-  the controller output is reset by setting <code>y</code>
-  to the value of the input signal <code>y_reset_in</code>.
+  input signal <code>trigger</code> and a real input signal <code>y_reset_in</code>
+  are enabled. Whenever the value of
+  <code>trigger</code> changes from <code>false</code> to <code>true</code>,
+  the controller output is reset by setting the value of <code>y</code>
+  to <code>y_reset_in</code>.
   </li>
 </ul>
 <p>
 Note that this controller implements an integrator anti-windup. Therefore,
 for most applications, keeping the default setting of
 <code>reset = IBPSA.Types.Reset.Disabled</code> is sufficient.
-Examples where it may be beneficial to reset the controller output are situations
+However, if the controller is used in conjuction with equipment that is being
+switched on, better control performance may be achieved by reseting the controller
+output when the equipment is switched on.
+This is in particular the case in situations
 where the equipment control input should continuously increase as the equipment is
 switched on, such as as a light dimmer that may slowly increase the luminance, or
 a variable speed drive of a motor that should continuously increase the speed.
 </p>
-</li>
+<h4>References</h4>
+<p>
+R. Montgomery and R. McDowall (2008).
+\"Fundamentals of HVAC Control Systems.\"
+American Society of Heating Refrigerating and Air-Conditioning Engineers Inc. Atlanta, GA.
+</p>
 
-<li>
-The parameter <code>limitsAtInit</code> has been removed.
-</li>
-
-<li>
-Some parameters assignments in the instances have been made final.
-</li>
-
-</ol>
 </html>",
 revisions="<html>
 <ul>
+<li>
+June 1, 2020, by Michael Wetter:<br/>
+Corrected wrong convention of reverse and direct action.<br/>
+Changed default configuration from PID to PI.<br/>
+This is for <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1365\">issue 1365</a>.
+</li>
 <li>
 March 9, 2020, by Michael Wetter:<br/>
 Corrected wrong unit declaration for parameter <code>k</code>.<br/>

--- a/IBPSA/Controls/Continuous/PIDHysteresis.mo
+++ b/IBPSA/Controls/Continuous/PIDHysteresis.mo
@@ -12,7 +12,7 @@ model PIDHysteresis
     "Value of hysteresis output at initial time"
     annotation (Dialog(group="Hysteresis"));
 
-  parameter Modelica.Blocks.Types.SimpleController controllerType=Modelica.Blocks.Types.SimpleController.PID
+  parameter Modelica.Blocks.Types.SimpleController controllerType=Modelica.Blocks.Types.SimpleController.PI
     "Type of controller"
     annotation (Dialog(group="Set point tracking"));
   parameter Real k=1 "Gain of controller"
@@ -33,9 +33,9 @@ model PIDHysteresis
     annotation (Dialog(group="Set point tracking"));
   parameter Real Nd=10 "The higher Nd, the more ideal the derivative block"
     annotation (Dialog(group="Set point tracking"));
-  parameter Boolean reverseAction = false
-    "Set to true to enable reverse action (such as for a cooling coil controller)"
-     annotation (Dialog(group="Set point tracking"));
+  parameter Boolean reverseActing = true
+    "Set to true for reverse acting, or false for direct acting control action"
+    annotation (Dialog(group="Set point tracking"));
 
   parameter Modelica.Blocks.Types.InitPID initType=Modelica.Blocks.Types.InitPID.DoNotUse_InitialIntegratorState
     "Type of initialization (1: no init, 2: steady state, 3: initial state, 4: initial output)"
@@ -67,7 +67,7 @@ model PIDHysteresis
     final xd_start=xd_start,
     final y_start=y_start,
     final Td=Td,
-    final reverseAction=reverseAction,
+    final reverseActing=reverseActing,
     final strict=strict) "Controller for room temperature"
     annotation (Placement(transformation(extent={{-30,-2},{-10,18}})));
   Modelica.Blocks.Logical.Hysteresis hys(
@@ -125,7 +125,8 @@ equation
   connect(swi1.y, PID.u_s) annotation (Line(
       points={{61,60},{70,60},{70,30},{-50,30},{-50,8},{-32,8}},
       color={0,0,127}));
-  annotation ( Icon(graphics={
+     annotation (Dialog(group="Set point tracking"),
+               Icon(graphics={
         Polygon(
           points={{-80,94},{-88,72},{-72,72},{-80,94}},
           lineColor={192,192,192},

--- a/IBPSA/Controls/Continuous/PIDHysteresisTimer.mo
+++ b/IBPSA/Controls/Continuous/PIDHysteresisTimer.mo
@@ -15,7 +15,7 @@ model PIDHysteresisTimer
     "Value of hysteresis output at initial time"
     annotation (Dialog(group="On/off controller"));
 
-  parameter Modelica.Blocks.Types.SimpleController controllerType=Modelica.Blocks.Types.SimpleController.PID
+  parameter Modelica.Blocks.Types.SimpleController controllerType=Modelica.Blocks.Types.SimpleController.PI
     "Type of controller"
       annotation (Dialog(group="Set point tracking"));
   parameter Real k=1 "Gain of controller"
@@ -37,8 +37,8 @@ model PIDHysteresisTimer
       annotation (Dialog(group="Set point tracking"));
   parameter Real Nd=10 "The higher Nd, the more ideal the derivative block"
       annotation (Dialog(group="Set point tracking"));
-  parameter Boolean reverseAction = false
-    "Set to true to enable reverse action (such as for a cooling coil controller)"
+  parameter Boolean reverseActing = true
+    "Set to true for reverse acting, or false for direct acting control action"
      annotation (Dialog(group="Set point tracking"));
 
   parameter Modelica.Blocks.Types.InitPID initType=Modelica.Blocks.Types.InitPID.DoNotUse_InitialIntegratorState
@@ -76,7 +76,7 @@ model PIDHysteresisTimer
     final y_start=y_start,
     final yMin=yMin,
     final yMax=yMax,
-    final reverseAction=reverseAction,
+    final reverseActing=reverseActing,
     final strict=strict) "Controller to track setpoint"
     annotation (Placement(transformation(extent={{-10,-60},{10,-40}})));
   OffTimer offHys

--- a/IBPSA/Fluid/Actuators/Dampers/Validation/PressureIndependent.mo
+++ b/IBPSA/Fluid/Actuators/Dampers/Validation/PressureIndependent.mo
@@ -49,6 +49,7 @@ model PressureIndependent
     annotation (Placement(transformation(extent={{0,-90},{20,-70}})));
   Controls.Continuous.LimPID conPID(k=10,
     Ti=0.001,
+    controllerType=Modelica.Blocks.Types.SimpleController.PID,
     initType=Modelica.Blocks.Types.InitPID.InitialState)
     "Discharge flow rate controller"
     annotation (Placement(transformation(extent={{-70,-70},{-50,-50}})));

--- a/IBPSA/Fluid/Examples/SimpleHouse.mo
+++ b/IBPSA/Fluid/Examples/SimpleHouse.mo
@@ -142,7 +142,8 @@ model SimpleHouse
     annotation (Placement(transformation(extent={{-60,-36},{-40,-16}})));
   Modelica.Blocks.Math.BooleanToInteger booleanToInt "Boolean to integer"
     annotation (Placement(transformation(extent={{-16,-144},{4,-124}})));
-  Controls.Continuous.LimPID conDam(controllerType=Modelica.Blocks.Types.SimpleController.P,
+  Controls.Continuous.LimPID conDam(
+      controllerType=Modelica.Blocks.Types.SimpleController.P,
       yMin=0.1) "Controller for damper"
     annotation (Placement(transformation(extent={{-20,80},{0,100}})));
   Modelica.Blocks.Sources.Constant TSetRoo(k=273.15 + 24)

--- a/IBPSA/Fluid/FMI/Adaptors/Examples/ThermalZoneHVACNoExhaust.mo
+++ b/IBPSA/Fluid/FMI/Adaptors/Examples/ThermalZoneHVACNoExhaust.mo
@@ -29,7 +29,6 @@ model ThermalZoneHVACNoExhaust
     startTime=7*3600) "Setpoint for room temperature"
     annotation (Placement(transformation(extent={{-120,40},{-100,60}})));
   Controls.Continuous.LimPID conPI(
-    controllerType=Modelica.Blocks.Types.SimpleController.PI,
     k=1,
     yMax=1,
     yMin=0,

--- a/IBPSA/Fluid/HeatExchangers/ActiveBeams/Examples/CoolingAndHeating.mo
+++ b/IBPSA/Fluid/HeatExchangers/ActiveBeams/Examples/CoolingAndHeating.mo
@@ -36,10 +36,8 @@ model CoolingAndHeating
   IBPSA.Controls.Continuous.LimPID conHea(
     yMax=0.094,
     Td=0,
-    reverseAction=false,
     Ti=100,
-    k=0.1,
-    controllerType=Modelica.Blocks.Types.SimpleController.PI)
+    k=0.1)
     "Controller for heating"
          annotation (Placement(transformation(extent={{-70,-20},{-50,0}})));
   Sources.MassFlowSource_T pumCoo(
@@ -80,11 +78,10 @@ model CoolingAndHeating
     annotation (Placement(transformation(extent={{-110,20},{-90,40}})));
   IBPSA.Controls.Continuous.LimPID conCoo(
     yMax=0.094,
-    reverseAction=true,
+    reverseActing=false,
     Td=0,
     k=0.5,
-    Ti=70,
-    controllerType=Modelica.Blocks.Types.SimpleController.PI)
+    Ti=70)
     "Controller for cooling"
     annotation (Placement(transformation(extent={{-70,20},{-50,40}})));
 
@@ -155,7 +152,7 @@ for both heating and cooling mode. An air volume is maintained at a temperature 
 <ul>
 <li>
 May 15, 2019, by Jianjun Hu:<br/>
-Replaced fluid source. This is for 
+Replaced fluid source. This is for
 <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1072\"> #1072</a>.
 </li>
 <li>

--- a/IBPSA/Fluid/HeatExchangers/ActiveBeams/Examples/CoolingOnly.mo
+++ b/IBPSA/Fluid/HeatExchangers/ActiveBeams/Examples/CoolingOnly.mo
@@ -34,11 +34,10 @@ model CoolingOnly
     "Outdoor air temperature"
     annotation (Placement(transformation(extent={{-110,-110},{-90,-90}})));
   IBPSA.Controls.Continuous.LimPID conPID(
-    reverseAction=true,
+    reverseActing=false,
     Td=0,
     k=0.5,
     Ti=70,
-    controllerType=Modelica.Blocks.Types.SimpleController.PI,
     yMax=0.094) "Controller"
          annotation (Placement(transformation(extent={{-70,-20},{-50,0}})));
   Sources.MassFlowSource_T pum(
@@ -119,7 +118,7 @@ that regulates the water flow rate in the active beam.
 <ul>
 <li>
 May 15, 2019, by Jianjun Hu:<br/>
-Replaced fluid source. This is for 
+Replaced fluid source. This is for
 <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1072\"> #1072</a>.
 </li>
 <li>

--- a/IBPSA/Fluid/HeatExchangers/ActiveBeams/Examples/HeatingOnly.mo
+++ b/IBPSA/Fluid/HeatExchangers/ActiveBeams/Examples/HeatingOnly.mo
@@ -36,10 +36,9 @@ model HeatingOnly
   IBPSA.Controls.Continuous.LimPID conPID(
     yMax=0.094,
     Td=0,
-    reverseAction=false,
+    reverseActing=true,
     Ti=100,
-    k=0.1,
-    controllerType=Modelica.Blocks.Types.SimpleController.PI) "Controller"
+    k=0.1) "Controller"
          annotation (Placement(transformation(extent={{-70,-20},{-50,0}})));
   IBPSA.Fluid.Sources.Boundary_pT sou_1(
     redeclare package Medium = MediumW,
@@ -133,7 +132,7 @@ that regulates the water flow rate in the active beam.
 <ul>
 <li>
 May 15, 2019, by Jianjun Hu:<br/>
-Replaced fluid source. This is for 
+Replaced fluid source. This is for
 <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1072\"> #1072</a>.
 </li>
 <li>

--- a/IBPSA/Fluid/HeatExchangers/Examples/BaseClasses/Heater.mo
+++ b/IBPSA/Fluid/HeatExchangers/Examples/BaseClasses/Heater.mo
@@ -48,7 +48,6 @@ partial model Heater "Base class for example model for the heater and cooler"
     y(final unit="K", displayUnit="degC")) "Setpoint for room temperature"
     annotation (Placement(transformation(extent={{-90,20},{-70,40}})));
   Controls.Continuous.LimPID conPI(
-    controllerType=Modelica.Blocks.Types.SimpleController.PI,
     k=1,
     yMax=1,
     yMin=0,
@@ -133,7 +132,7 @@ and it also is required to account for a variation of density of the fluid.
 <ul>
 <li>
 May 15, 2019, by Jianjun Hu:<br/>
-Replaced fluid source. This is for 
+Replaced fluid source. This is for
 <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1072\"> #1072</a>.
 </li>
 <li>

--- a/IBPSA/Fluid/HeatExchangers/Examples/DryCoilEffectivenessNTUPControl.mo
+++ b/IBPSA/Fluid/HeatExchangers/Examples/DryCoilEffectivenessNTUPControl.mo
@@ -62,7 +62,6 @@ model DryCoilEffectivenessNTUPControl
     dpValve_nominal=6000) "Valve"
     annotation (Placement(transformation(extent={{30,50},{50,70}})));
   IBPSA.Controls.Continuous.LimPID P(
-    controllerType=Modelica.Blocks.Types.SimpleController.PI,
     Ti=30,
     k=0.1,
     Td=1)

--- a/IBPSA/Fluid/HeatExchangers/Validation/HeaterCooler_u.mo
+++ b/IBPSA/Fluid/HeatExchangers/Validation/HeaterCooler_u.mo
@@ -33,7 +33,6 @@ model HeaterCooler_u "Model that demonstrates the ideal heater model"
     "Setpoint"
     annotation (Placement(transformation(extent={{-60,140},{-40,160}})));
   IBPSA.Controls.Continuous.LimPID con1(
-    controllerType=Modelica.Blocks.Types.SimpleController.PI,
     Td=1,
     k=1,
     Ti=10)
@@ -53,7 +52,6 @@ model HeaterCooler_u "Model that demonstrates the ideal heater model"
     annotation (Placement(transformation(extent={{40,-20},{60,0}})));
 
   IBPSA.Controls.Continuous.LimPID con2(
-    controllerType=Modelica.Blocks.Types.SimpleController.PI,
     Td=1,
     Ti=10,
     k=0.1)

--- a/IBPSA/Fluid/Humidifiers/Examples/Humidifier_u.mo
+++ b/IBPSA/Fluid/Humidifiers/Examples/Humidifier_u.mo
@@ -34,8 +34,7 @@ model Humidifier_u "Model that demonstrates the ideal humidifier model"
     Td=1,
     k=1,
     Ti=10,
-    controllerType=Modelica.Blocks.Types.SimpleController.PI,
-    reverseAction=true) "Controller"
+    reverseActing=false) "Controller"
     annotation (Placement(transformation(extent={{40,140},{60,160}})));
   IBPSA.Fluid.Humidifiers.Humidifier_u humDyn(
     redeclare package Medium = Medium,
@@ -53,8 +52,7 @@ model Humidifier_u "Model that demonstrates the ideal humidifier model"
     Td=1,
     Ti=10,
     k=0.1,
-    controllerType=Modelica.Blocks.Types.SimpleController.PI,
-    reverseAction=true) "Controller"
+    reverseActing=false) "Controller"
     annotation (Placement(transformation(extent={{40,30},{60,50}})));
   IBPSA.Fluid.Sources.Boundary_pT sin(
     redeclare package Medium = Medium,

--- a/IBPSA/Fluid/MixingVolumes/Examples/MixingVolumeMoistAir.mo
+++ b/IBPSA/Fluid/MixingVolumes/Examples/MixingVolumeMoistAir.mo
@@ -54,14 +54,12 @@ model MixingVolumeMoistAir "Test model for mixing volume with moist air input"
     k=1,
     Ti=1,
     Td=1,
-    controllerType=Modelica.Blocks.Types.SimpleController.PI,
     wd=0,
     yMin=-1000)
     annotation (Placement(transformation(extent={{-40,120},{-20,140}})));
   IBPSA.Controls.Continuous.LimPID PI1(
     Ni=0.1,
     Ti=1,
-    controllerType=Modelica.Blocks.Types.SimpleController.PI,
     k=10,
     yMax=1,
     yMin=-1,

--- a/IBPSA/Fluid/Movers/Examples/ClosedLoop_y.mo
+++ b/IBPSA/Fluid/Movers/Examples/ClosedLoop_y.mo
@@ -42,7 +42,6 @@ model ClosedLoop_y "Flow machine with feedback control"
     annotation (Placement(transformation(extent={{-40,40},{-20,60}})));
   IBPSA.Controls.Continuous.LimPID conPID(
     Td=1,
-    controllerType=Modelica.Blocks.Types.SimpleController.PI,
     k=0.5,
     Ti=15) annotation (Placement(transformation(extent={{0,100},{20,120}})));
   Modelica.Blocks.Math.Gain gain1(k=1/m_flow_nominal)

--- a/IBPSA/Fluid/Sensors/Conversions/Examples/To_VolumeFraction.mo
+++ b/IBPSA/Fluid/Sensors/Conversions/Examples/To_VolumeFraction.mo
@@ -11,8 +11,7 @@ model To_VolumeFraction "Example problem for conversion model"
     "Set point for volume fraction of 700PPM CO2"
     annotation (Placement(transformation(extent={{-180,-20},{-160,0}})));
   IBPSA.Controls.Continuous.LimPID limPID(
-    controllerType=Modelica.Blocks.Types.SimpleController.PI,
-    reverseAction=true,
+    reverseActing=false,
     Ti=600,
     k=2,
     Td=1)
@@ -155,7 +154,7 @@ the setpoint, which does not comply with ASHRAE regulations.
 <ul>
 <li>
 May 2, 2019, by Jianjun Hu:<br/>
-Replaced fluid source. This is for 
+Replaced fluid source. This is for
 <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1072\"> #1072</a>.
 </li>
 <li>

--- a/IBPSA/ThermalZones/ReducedOrder/Validation/VDI6007/TestCase11.mo
+++ b/IBPSA/ThermalZones/ReducedOrder/Validation/VDI6007/TestCase11.mo
@@ -114,7 +114,6 @@ model TestCase11 "VDI 6007 Test Case 11 model"
   Controls.Continuous.LimPID conHeaCoo(
     yMin=-1,
     Td=5,
-    controllerType=Modelica.Blocks.Types.SimpleController.PI,
     yMax=1,
     k=0.1,
     Ti=1.2)

--- a/IBPSA/ThermalZones/ReducedOrder/Validation/VDI6007/TestCase7.mo
+++ b/IBPSA/ThermalZones/ReducedOrder/Validation/VDI6007/TestCase7.mo
@@ -95,7 +95,6 @@ model TestCase7 "VDI 6007 Test Case 7 model"
     "Convert set temperature from degC to Kelvin"
     annotation (Placement(transformation(extent={{-38,-42},{-26,-30}})));
   Controls.Continuous.LimPID conHeaCoo(
-    controllerType=Modelica.Blocks.Types.SimpleController.PI,
     yMax=1,
     yMin=-1,
     k=0.1,

--- a/IBPSA/Utilities/IO/SignalExchange/Examples/BaseClasses/OriginalModel.mo
+++ b/IBPSA/Utilities/IO/SignalExchange/Examples/BaseClasses/OriginalModel.mo
@@ -6,7 +6,6 @@ model OriginalModel "Original model"
     annotation (Placement(transformation(extent={{-70,20},{-50,40}})));
 
   Modelica.Blocks.Continuous.LimPID conPI(
-    controllerType=Modelica.Blocks.Types.SimpleController.PI,
     yMax=10) "Controller"
     annotation (Placement(transformation(extent={{-10,20},{10,40}})));
 


### PR DESCRIPTION
This closes #1365

This changes `reverseAction` to `reverseActing`, and corrects the meaning of this parameter to comply with the convention used in the HVAC industry.

This also changes the default from PID to PI.

This changes is for all three PID controllers in `IBPSA.Controls.Continuous`.

Todo: 
- [ ] Add conversion scripts