### PR TITLE
added missing right bracket, #1420

### DIFF
--- a/IBPSA/BoundaryConditions/WeatherData/BaseClasses/PartialLimiter.mo
+++ b/IBPSA/BoundaryConditions/WeatherData/BaseClasses/PartialLimiter.mo
@@ -13,7 +13,7 @@ annotation (
 defaultComponentName="lim",
 Documentation(info="<html>
 <p>
-Block that computes <i>y_internal=min(uMax, max(uMin, u)</i>,
+Block that computes <i>y_internal=min(uMax, max(uMin, u))</i>,
 where <code>y_internal</code> is a protected connector.
 </p>
 <p>


### PR DESCRIPTION
This closes #1420.

- [x] added missing `)` to the info section of `BoundaryConditions.WeatherData.BaseClasses.PartialLimiter`.