### PR TITLE
Better error message for out of bound eps

### DIFF
--- a/IBPSA/Fluid/HeatExchangers/BaseClasses/PartialEffectivenessNTU.mo
+++ b/IBPSA/Fluid/HeatExchangers/BaseClasses/PartialEffectivenessNTU.mo
@@ -114,7 +114,7 @@ initial equation
   assert(eps_nominal > 0 and eps_nominal < 1,
     "eps_nominal out of bounds, eps_nominal = " + String(eps_nominal) +
     "\n  To achieve the required heat transfer rate at epsilon=0.8, set |T_a1_nominal-T_a2_nominal| = "
-     + String(abs(Q_flow_nominal/0.8*CMin_flow_nominal)) +
+     + String(abs(Q_flow_nominal/0.8/CMin_flow_nominal)) +
     "\n  or increase flow rates. The current parameters result in " +
     "\n  CMin_flow_nominal = " + String(CMin_flow_nominal) +
     "\n  CMax_flow_nominal = " + String(CMax_flow_nominal));

--- a/IBPSA/Fluid/HeatExchangers/BaseClasses/PartialEffectivenessNTU.mo
+++ b/IBPSA/Fluid/HeatExchangers/BaseClasses/PartialEffectivenessNTU.mo
@@ -103,8 +103,7 @@ initial equation
   Q_flow_nominal = m1_flow_nominal*cp1_nominal*(T_a1_nominal - T_b1_nominal);
   if use_Q_flow_nominal then
     Q_flow_nominal = -m2_flow_nominal*cp2_nominal*(T_a2_nominal - T_b2_nominal);
-    eps_nominal = abs(Q_flow_nominal/((T_a1_nominal - T_a2_nominal)*
-      CMin_flow_nominal));
+    eps_nominal = Q_flow_nominal/((T_a1_nominal - T_a2_nominal)*CMin_flow_nominal);
   else
     T_a1_nominal = Medium1.T_default;
     T_a2_nominal = Medium2.T_default;
@@ -113,8 +112,8 @@ initial equation
   end if;
   assert(eps_nominal > 0 and eps_nominal < 1,
     "eps_nominal out of bounds, eps_nominal = " + String(eps_nominal) +
-    "\n  To achieve the required heat transfer rate at epsilon=0.8, set |T_a1_nominal-T_a2_nominal| = "
-     + String(abs(Q_flow_nominal/0.8*CMin_flow_nominal)) +
+    "\n  To achieve the required heat transfer rate at epsilon=0.8, set T_a1_nominal-T_a2_nominal = "
+     + String(Q_flow_nominal/0.8/CMin_flow_nominal) +
     "\n  or increase flow rates. The current parameters result in " +
     "\n  CMin_flow_nominal = " + String(CMin_flow_nominal) +
     "\n  CMax_flow_nominal = " + String(CMax_flow_nominal));

--- a/IBPSA/Fluid/HeatExchangers/BaseClasses/PartialEffectivenessNTU.mo
+++ b/IBPSA/Fluid/HeatExchangers/BaseClasses/PartialEffectivenessNTU.mo
@@ -103,7 +103,8 @@ initial equation
   Q_flow_nominal = m1_flow_nominal*cp1_nominal*(T_a1_nominal - T_b1_nominal);
   if use_Q_flow_nominal then
     Q_flow_nominal = -m2_flow_nominal*cp2_nominal*(T_a2_nominal - T_b2_nominal);
-    eps_nominal = Q_flow_nominal/((T_a1_nominal - T_a2_nominal)*CMin_flow_nominal);
+    eps_nominal = abs(Q_flow_nominal/((T_a1_nominal - T_a2_nominal)*
+      CMin_flow_nominal));
   else
     T_a1_nominal = Medium1.T_default;
     T_a2_nominal = Medium2.T_default;
@@ -112,8 +113,8 @@ initial equation
   end if;
   assert(eps_nominal > 0 and eps_nominal < 1,
     "eps_nominal out of bounds, eps_nominal = " + String(eps_nominal) +
-    "\n  To achieve the required heat transfer rate at epsilon=0.8, set T_a1_nominal-T_a2_nominal = "
-     + String(Q_flow_nominal/0.8/CMin_flow_nominal) +
+    "\n  To achieve the required heat transfer rate at epsilon=0.8, set |T_a1_nominal-T_a2_nominal| = "
+     + String(abs(Q_flow_nominal/0.8*CMin_flow_nominal)) +
     "\n  or increase flow rates. The current parameters result in " +
     "\n  CMin_flow_nominal = " + String(CMin_flow_nominal) +
     "\n  CMax_flow_nominal = " + String(CMax_flow_nominal));


### PR DESCRIPTION
Originally this change was only to fix the calculation in the error message, but looking further into it, I also figured that the `abs` is redundant in the calculation of `eps_nominal`.

Reasoning: Without the `abs`, you could rewrite the `eps_nominal` equation like so:
```
    eps_nominal = (T_b2_nominal - T_a2_nominal) / (T_a1_nominal - T_a2_nominal)
```

The factor `(T_b2_nominal - T_a2_nominal) / (T_a1_nominal - T_a2_nominal)` is always positive when the user selected nominal values are right: side 2 is heating up (b2 >= a2) if and only if side 1 comes in hotter (a1 >= a2). If the values are wrong, then the following `assert` statement would catch it (`eps_nominal < 0`).