### PR TITLE
Changed filter for #1498, removed parameter order=2

### DIFF
--- a/IBPSA/Fluid/Actuators/BaseClasses/ActuatorSignal.mo
+++ b/IBPSA/Fluid/Actuators/BaseClasses/ActuatorSignal.mo
@@ -8,8 +8,6 @@ model ActuatorSignal
   parameter Modelica.SIunits.Time riseTime=120
     "Rise time of the filter (time to reach 99.6 % of an opening step)"
     annotation(Dialog(tab="Dynamics", group="Filtered opening",enable=use_inputFilter));
-  parameter Integer order(min=1) = 2 "Order of filter"
-    annotation(Dialog(tab="Dynamics", group="Filtered opening",enable=use_inputFilter));
   parameter Modelica.Blocks.Types.Init init=Modelica.Blocks.Types.Init.InitialOutput
     "Type of initialization (no init/steady state/initial state/initial output)"
     annotation(Dialog(tab="Dynamics", group="Filtered opening",enable=use_inputFilter));
@@ -41,30 +39,25 @@ protected
     annotation (Placement(transformation(extent={{40,78},{60,98}}),
         iconTransformation(extent={{60,50},{80,70}})));
 
-  Modelica.Blocks.Continuous.Filter filter(
-     final order=order,
-     f_cut=5/(2*Modelica.Constants.pi*riseTime),
-     final init=init,
-     final y_start=y_start,
-     final analogFilter=Modelica.Blocks.Types.AnalogFilter.CriticalDamping,
-     final filterType=Modelica.Blocks.Types.FilterType.LowPass,
-     x(each stateSelect=StateSelect.always,
-       each start=0)) if
-        use_inputFilter
+  Modelica.Blocks.Continuous.CriticalDamping filter(
+    final n=2,
+    final f=5/(2*Modelica.Constants.pi*riseTime),
+    final normalized=true,
+    final initType=Modelica.Blocks.Types.Init.InitialOutput,
+    final y_start=y_start,
+    x(each final stateSelect=StateSelect.always,
+      each final start=0)) if use_inputFilter
     "Second order filter to approximate valve opening time, and to improve numerics"
     annotation (Placement(transformation(extent={{6,81},{20,95}})));
 
 equation
- connect(filter.y, y_filtered) annotation (Line(
-      points={{20.7,88},{50,88}},
-      color={0,0,127}));
+  connect(filter.y, y_filtered)
+    annotation (Line(points={{20.7,88},{50,88}}, color={0,0,127}));
   if use_inputFilter then
-  connect(y, filter.u) annotation (Line(
-      points={{1.11022e-15,120},{1.11022e-15,88},{4.6,88}},
-      color={0,0,127}));
-  connect(filter.y, y_internal) annotation (Line(
-      points={{20.7,88},{30,88},{30,70},{50,70}},
-      color={0,0,127}));
+    connect(y, filter.u) annotation (Line(points={{1.11022e-15,120},{1.11022e-15,
+            88},{4.6,88}}, color={0,0,127}));
+    connect(filter.y, y_internal) annotation (Line(points={{20.7,88},{30,88},{30,
+            70},{50,70}}, color={0,0,127}));
   else
     connect(y, y_internal) annotation (Line(
       points={{1.11022e-15,120},{0,120},{0,70},{50,70}},
@@ -112,10 +105,6 @@ Models that extend this model use the signal
 current position of the actuator.
 </p>
 <p>
-The filter order can be changed to modify the transient response
-of the actuator.
-</p>
-<p>
 See
 <a href=\"modelica://IBPSA.Fluid.Actuators.UsersGuide\">
 IBPSA.Fluid.Actuators.UsersGuide</a>
@@ -123,6 +112,12 @@ for a description of the filter.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+June 10, 2021, by Michael Wetter:<br/>
+Changed implementation of the filter and removed the parameter <code>order</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1498\">#1498</a>.
+</li>
 <li>
 April 6, 2020, by Antoine Gautier:<br/>
 Add the boolean parameter <code>casePreInd</code>.<br/>


### PR DESCRIPTION
This closes #1498.

It removes the parameter `order=2` and uses a simpler implementation of the filter.

Todo:
Add conversion script due to removal of parameter `order`.