### PR TITLE
Make BaseProperties replaceable in Media.Air

### DIFF
--- a/IBPSA/Media/Air.mo
+++ b/IBPSA/Media/Air.mo
@@ -20,6 +20,28 @@ package Air
   constant Integer Air=2
     "Index of air (in substanceNames, massFractions X, etc.)";
 
+  // In the assignments below, we compute cv as OpenModelica
+  // cannot evaluate cv=cp-R as defined in GasProperties.
+  constant GasProperties dryair(
+    R =    Modelica.Media.IdealGases.Common.SingleGasesData.Air.R,
+    MM =   Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM,
+    cp =   IBPSA.Utilities.Psychrometrics.Constants.cpAir,
+    cv =   IBPSA.Utilities.Psychrometrics.Constants.cpAir
+             -Modelica.Media.IdealGases.Common.SingleGasesData.Air.R)
+    "Dry air properties";
+  constant GasProperties steam(
+    R =    Modelica.Media.IdealGases.Common.SingleGasesData.H2O.R,
+    MM =   Modelica.Media.IdealGases.Common.SingleGasesData.H2O.MM,
+    cp =   IBPSA.Utilities.Psychrometrics.Constants.cpSte,
+    cv =   IBPSA.Utilities.Psychrometrics.Constants.cpSte
+             -Modelica.Media.IdealGases.Common.SingleGasesData.H2O.R)
+    "Steam properties";
+
+  constant Real k_mair =  steam.MM/dryair.MM "Ratio of molar weights";
+
+  constant Modelica.SIunits.MolarMass[2] MMX={steam.MM,dryair.MM}
+    "Molar masses of components";
+
   constant AbsolutePressure pStp = reference_p
     "Pressure for which fluid density is defined";
   constant Density dStp = 1.2 "Fluid density at pressure pStp";
@@ -872,27 +894,6 @@ First implementation.
 </ul>
 </html>"));
   end GasProperties;
-  // In the assignments below, we compute cv as OpenModelica
-  // cannot evaluate cv=cp-R as defined in GasProperties.
-  constant GasProperties dryair(
-    R =    Modelica.Media.IdealGases.Common.SingleGasesData.Air.R,
-    MM =   Modelica.Media.IdealGases.Common.SingleGasesData.Air.MM,
-    cp =   IBPSA.Utilities.Psychrometrics.Constants.cpAir,
-    cv =   IBPSA.Utilities.Psychrometrics.Constants.cpAir
-             -Modelica.Media.IdealGases.Common.SingleGasesData.Air.R)
-    "Dry air properties";
-  constant GasProperties steam(
-    R =    Modelica.Media.IdealGases.Common.SingleGasesData.H2O.R,
-    MM =   Modelica.Media.IdealGases.Common.SingleGasesData.H2O.MM,
-    cp =   IBPSA.Utilities.Psychrometrics.Constants.cpSte,
-    cv =   IBPSA.Utilities.Psychrometrics.Constants.cpSte
-             -Modelica.Media.IdealGases.Common.SingleGasesData.H2O.R)
-    "Steam properties";
-
-  constant Real k_mair =  steam.MM/dryair.MM "Ratio of molar weights";
-
-  constant Modelica.SIunits.MolarMass[2] MMX={steam.MM,dryair.MM}
-    "Molar masses of components";
 
   constant Modelica.SIunits.SpecificEnergy h_fg=
     IBPSA.Utilities.Psychrometrics.Constants.h_fg

--- a/IBPSA/Media/Air.mo
+++ b/IBPSA/Media/Air.mo
@@ -45,7 +45,7 @@ package Air
   // Therefore, the statement
   //   p(stateSelect=if preferredMediumStates then StateSelect.prefer else StateSelect.default)
   // has been removed.
-  redeclare model BaseProperties "Base properties (p, d, T, h, u, R, MM and X and Xi) of a medium"
+  redeclare replaceable model BaseProperties "Base properties (p, d, T, h, u, R, MM and X and Xi) of a medium"
 
   parameter Boolean preferredMediumStates=false
     "= true if StateSelect.prefer shall be used for the independent property variables of the medium"


### PR DESCRIPTION
This PR contains the changes from https://github.com/ibpsa/modelica-ibpsa/pull/1515

It makes the `BaseProperties` in `Media.Air` replaceable so that they can be change for compatibility with `Modelica.Media.Air.MoistAir`. 

Making `IBPSA.Media.Air` compatible would require introducing a call to `p_steam_sat = min(saturationPressure(T), 0.999*p);` which is an expensive function in the `BaseProperties`. Also, it would introduce `p_steam_sat`, which may be confusing to users because we don't model the amount of steam vs condensed water.