### PR TITLE
Included ModelicaAllocateString.h in cryptographicsHash.c

### DIFF
--- a/IBPSA/Resources/C-Sources/cryptographicsHash.c
+++ b/IBPSA/Resources/C-Sources/cryptographicsHash.c
@@ -24,6 +24,7 @@ A million repetitions of "a"
 /* for uint32_t */
 #include <stdint.h>
 #include "cryptographicsHash.h"
+#include "ModelicaUtilities.h"
 
 
 #define rol(value, bits) (((value) << (bits)) | ((value) >> (32 - (bits))))


### PR DESCRIPTION
This integrates https://github.com/lbl-srg/modelica-buildings/pull/2784
It avoids a wrong memory access in OpenModelica