### PR TITLE
Corrected wrong port name

### DIFF
--- a/IBPSA/Fluid/Interfaces/PartialEightPortInterface.mo
+++ b/IBPSA/Fluid/Interfaces/PartialEightPortInterface.mo
@@ -96,7 +96,7 @@ partial model PartialEightPortInterface
                           noEvent(actualStream(port_a3.h_outflow)),
                           noEvent(actualStream(port_a3.Xi_outflow)))
     else
-      Medium3.setState_phX(port_a.p,
+      Medium3.setState_phX(port_a3.p,
                           inStream(port_a3.h_outflow),
                           inStream(port_a3.Xi_outflow))
       if show_T "Medium properties in port_a3";


### PR DESCRIPTION
This corrects the name of a port. The old implementation used a port name that does not exist.