### PR TITLE
Issue1585 protected se block

### DIFF
--- a/IBPSA/Utilities/IO/SignalExchange/Overwrite.mo
+++ b/IBPSA/Utilities/IO/SignalExchange/Overwrite.mo
@@ -55,6 +55,11 @@ by modifying its attributes.
 revisions="<html>
 <ul>
 <li>
+February 17, 2022 by David Blum:<br/>
+Made parameter <code>boptestOverwrite</code> unprotected.
+This is for <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1585\">#1585</a>.
+</li>
+<li>
 July 17, 2019 by Michael Wetter:<br/>
 Changed parameter name from <code>Description</code> to <code>description</code>.
 </li>

--- a/IBPSA/Utilities/IO/SignalExchange/Overwrite.mo
+++ b/IBPSA/Utilities/IO/SignalExchange/Overwrite.mo
@@ -4,6 +4,9 @@ block Overwrite "Block that allows a signal to overwritten by an FMU input"
 
   parameter String description "Description of the signal being overwritten";
 
+  final parameter Boolean boptestOverwrite = true
+    "Parameter that is used by tools to search for overwrite block in models";
+
   Modelica.Blocks.Logical.Switch swi
     "Switch between external signal and direct feedthrough signal"
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
@@ -12,8 +15,6 @@ block Overwrite "Block that allows a signal to overwritten by an FMU input"
   Modelica.Blocks.Sources.BooleanExpression activate
     "Block to activate use of external signal"
     annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
-  final parameter Boolean boptestOverwrite = true
-    "Protected parameter, used by tools to search for overwrite block in models";
 
 equation
   connect(activate.y, swi.u2)

--- a/IBPSA/Utilities/IO/SignalExchange/Overwrite.mo
+++ b/IBPSA/Utilities/IO/SignalExchange/Overwrite.mo
@@ -12,7 +12,6 @@ block Overwrite "Block that allows a signal to overwritten by an FMU input"
   Modelica.Blocks.Sources.BooleanExpression activate
     "Block to activate use of external signal"
     annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
-protected
   final parameter Boolean boptestOverwrite = true
     "Protected parameter, used by tools to search for overwrite block in models";
 

--- a/IBPSA/Utilities/IO/SignalExchange/Read.mo
+++ b/IBPSA/Utilities/IO/SignalExchange/Read.mo
@@ -58,6 +58,11 @@ the parameter <code>zone</code> for more details.
 revisions="<html>
 <ul>
 <li>
+February 17, 2022 by David Blum:<br/>
+Made parameter <code>boptestRead</code> unprotected.
+This is for <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1585\">#1585</a>.
+</li>
+<li>
 February 23, 2020 by David Blum:<br/>
 Added zone designation for KPI calculation by parameter <code>zone</code>.
 See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1257\">#1257</a>.

--- a/IBPSA/Utilities/IO/SignalExchange/Read.mo
+++ b/IBPSA/Utilities/IO/SignalExchange/Read.mo
@@ -24,7 +24,8 @@ model Read "Block that allows a signal to be read as an FMU output"
     KPIs==IBPSA.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.CO2Concentration)));
 
   final parameter Boolean boptestRead = true
-    "Protected parameter, used by tools to search for read block in models";
+    "Parameter that is used by tools to search for read block in models";
+
   annotation (Documentation(info="<html>
 <p>
 This block enables the reading of a signal and its meta-data by an external

--- a/IBPSA/Utilities/IO/SignalExchange/Read.mo
+++ b/IBPSA/Utilities/IO/SignalExchange/Read.mo
@@ -23,7 +23,6 @@ model Read "Block that allows a signal to be read as an FMU output"
     KPIs==IBPSA.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.RelativeHumidity or
     KPIs==IBPSA.Utilities.IO.SignalExchange.SignalTypes.SignalsForKPIs.CO2Concentration)));
 
-protected
   final parameter Boolean boptestRead = true
     "Protected parameter, used by tools to search for read block in models";
   annotation (Documentation(info="<html>


### PR DESCRIPTION
This is for https://github.com/ibpsa/modelica-ibpsa/issues/1585.  Namely, it makes the parameters ``IBPSA.Utilities.IO.SignalExchange.Read.boptestRead`` and ``IBPSA.Utilities.IO.SignalExchange.Overwrite.boptestOverwrite`` unprotected.

@kbenne this should solve your problem with compiling BOPTEST test case using Spawn.