### PR TITLE
Issue1542. Remove massDynamics

### DIFF
--- a/IBPSA/Airflow/Multizone/MediumColumnDynamic.mo
+++ b/IBPSA/Airflow/Multizone/MediumColumnDynamic.mo
@@ -1,7 +1,8 @@
 within IBPSA.Airflow.Multizone;
 model MediumColumnDynamic
   "Vertical shaft with no friction and storage of heat and mass"
-  extends IBPSA.Fluid.Interfaces.LumpedVolumeDeclarations;
+  extends IBPSA.Fluid.Interfaces.LumpedVolumeDeclarations(
+    final massDynamics=energyDynamics);
 
   replaceable package Medium =
     Modelica.Media.Interfaces.PartialMedium "Medium in the component"
@@ -180,6 +181,12 @@ at the top of the column.
 </html>",
 revisions="<html>
 <ul>
+<li>
+March 7, 2022, by Michael Wetter:<br/>
+Set <code>final massDynamics=energyDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
 <li>
 January 18, 2019, by Jianjun Hu:<br/>
 Limited the media choice to moist air only.

--- a/IBPSA/Fluid/Actuators/Valves/ThreeWayEqualPercentageLinear.mo
+++ b/IBPSA/Fluid/Actuators/Valves/ThreeWayEqualPercentageLinear.mo
@@ -55,6 +55,12 @@ for the implementation of the regularization near the origin.
 revisions="<html>
 <ul>
 <li>
+March 7, 2022, by Michael Wetter:<br/>
+Set <code>final massDynamics=energyDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
+<li>
 June 10, 2021, by Michael Wetter:<br/>
 Changed implementation of the filter and changed the parameter <code>order</code> to a constant
 as most users need not change this value.<br/>

--- a/IBPSA/Fluid/Actuators/Valves/ThreeWayLinear.mo
+++ b/IBPSA/Fluid/Actuators/Valves/ThreeWayLinear.mo
@@ -38,6 +38,12 @@ for the implementation of the regularization near the origin.
 revisions="<html>
 <ul>
 <li>
+March 7, 2022, by Michael Wetter:<br/>
+Set <code>final massDynamics=energyDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
+<li>
 June 10, 2021, by Michael Wetter:<br/>
 Changed implementation of the filter and changed the parameter <code>order</code> to a constant
 as most users need not change this value.<br/>

--- a/IBPSA/Fluid/Actuators/Valves/ThreeWayTable.mo
+++ b/IBPSA/Fluid/Actuators/Valves/ThreeWayTable.mo
@@ -114,6 +114,12 @@ IBPSA.Fluid.Actuators.Valves.Examples.TwoWayValveTable</a>.
 revisions="<html>
 <ul>
 <li>
+March 7, 2022, by Michael Wetter:<br/>
+Set <code>final massDynamics=energyDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
+<li>
 June 10, 2021, by Michael Wetter:<br/>
 Changed implementation of the filter and changed the parameter <code>order</code> to a constant
 as most users need not change this value.<br/>

--- a/IBPSA/Fluid/BaseClasses/PartialThreeWayResistance.mo
+++ b/IBPSA/Fluid/BaseClasses/PartialThreeWayResistance.mo
@@ -2,6 +2,7 @@ within IBPSA.Fluid.BaseClasses;
 partial model PartialThreeWayResistance
   "Flow splitter with partial resistance model at each port"
   extends IBPSA.Fluid.Interfaces.LumpedVolumeDeclarations(
+    final massDynamics=energyDynamics,
     final mSenFac=1);
 
   Modelica.Fluid.Interfaces.FluidPort_a port_1(
@@ -153,7 +154,7 @@ equation
     end if;
     if portFlowDirection_3==Modelica.Fluid.Types.PortFlowDirection.Leaving then
       assert(port_3.m_flow< m_flow_small,
-      "In " + getInstanceName() + ": 
+      "In " + getInstanceName() + ":
       Flow is entering port_3 despite portFlowDirection_3=PortFlowDirection.Leaving, since m_flow=" +
       String(port_3.m_flow) + ">"+String(m_flow_small));
     end if;
@@ -247,14 +248,20 @@ The time constant of the mixing volume is determined by the parameter <code>tau<
 </html>", revisions="<html>
 <ul>
 <li>
+March 7, 2022, by Michael Wetter:<br/>
+Set <code>final massDynamics=energyDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
+<li>
 March 22, 2020, by Filip Jorissen:<br/>
-Corrected error message of asserts that verify whether flow reversal occurs when 
+Corrected error message of asserts that verify whether flow reversal occurs when
 <code>verifyFlowReversal=true</code> and <code>portFlowDirection&lt;&gt;Bidirectional</code>.
 See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1327\">#1327</a>.
 </li>
 <li>
 July 7, 2018, by Filip Jorissen:<br/>
-Added asserts that verify whether flow reversal occurs when 
+Added asserts that verify whether flow reversal occurs when
 <code>verifyFlowReversal=true</code> and <code>portFlowDirection&lt;&gt;Bidirectional</code>.
 See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/963\">#963</a>.
 </li>

--- a/IBPSA/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/InternalHEXOneUTube.mo
+++ b/IBPSA/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/InternalHEXOneUTube.mo
@@ -12,14 +12,14 @@ model InternalHEXOneUTube
     final tau2=VTubSeg*rho2_nominal/m2_flow_nominal,
     redeclare final IBPSA.Fluid.MixingVolumes.MixingVolume vol1(
       final energyDynamics=energyDynamics,
-      final massDynamics=massDynamics,
+      final massDynamics=energyDynamics,
       final prescribedHeatFlowRate=false,
       final m_flow_small=m1_flow_small,
       final V=VTubSeg,
       final mSenFac=mSenFac),
     redeclare final IBPSA.Fluid.MixingVolumes.MixingVolume vol2(
       final energyDynamics=energyDynamics,
-      final massDynamics=massDynamics,
+      final massDynamics=energyDynamics,
       final prescribedHeatFlowRate=false,
       final m_flow_small=m2_flow_small,
       final V=VTubSeg,
@@ -97,7 +97,7 @@ initial equation
 
 equation
     assert(borFieDat.conDat.borCon == IBPSA.Fluid.Geothermal.Borefields.Types.BoreholeConfiguration.SingleUTube,
-  "This model should be used for single U-type borefield, not double U-type. 
+  "This model should be used for single U-type borefield, not double U-type.
   Check that the conDat record has been correctly parametrized");
   connect(RVol2.y, RConv2.Rc) annotation (Line(points={{-79,-8},{-60,-8},{-40,
           -8},{-40,-28},{-12,-28}},
@@ -130,23 +130,23 @@ equation
     Documentation(info="<html>
 <p>
 Model for the heat transfer between the fluid and within the borehole filling
-for a single borehole segment. 
-This model computes the dynamic response of the fluid in the tubes, 
-the heat transfer between the fluid and the borehole filling, 
+for a single borehole segment.
+This model computes the dynamic response of the fluid in the tubes,
+the heat transfer between the fluid and the borehole filling,
 and the heat storage within the fluid and the borehole filling.
 </p>
 <p>
-This model computes the different thermal resistances present 
-in a single-U-tube borehole using the method of Bauer et al. (2011) 
-and computing explicitely the fluid-to-ground thermal resistance 
-<i>R<sub>b</sub></i> and the 
+This model computes the different thermal resistances present
+in a single-U-tube borehole using the method of Bauer et al. (2011)
+and computing explicitely the fluid-to-ground thermal resistance
+<i>R<sub>b</sub></i> and the
 grout-to-grout resistance
 <i>R<sub>a</sub></i> as defined by Claesson and Hellstrom (2011)
-using the multipole method. 
+using the multipole method.
 </p>
 <h4>References</h4>
-<p>J. Claesson and G. Hellstrom. 
-<i>Multipole method to calculate borehole thermal resistances in a borehole heat exchanger. 
+<p>J. Claesson and G. Hellstrom.
+<i>Multipole method to calculate borehole thermal resistances in a borehole heat exchanger.
 </i>
 HVAC&amp;R Research,
 17(6): 895-911, 2011.</p>
@@ -159,6 +159,12 @@ International Journal Of Energy Research, 35:312-320, 2011.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 7, 2022, by Michael Wetter:<br/>
+Removed <code>massDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
 <li>
 July 10, 2018, by Alex Laferri&egrave;re:<br/>
 Updated documentation following major changes to the IBPSA.Fluid.HeatExchangers.Ground package.
@@ -175,7 +181,7 @@ Removed unused parameters <code>B0</code> and <code>B1</code>.
 </li>
 <li>
 January 24, 2014, by Michael Wetter:<br/>
-Revised implementation, added comments, replaced 
+Revised implementation, added comments, replaced
 <code>HeatTransfer.Windows.BaseClasses.ThermalConductor</code>
 with resistance models from the Modelica Standard Library.
 </li>

--- a/IBPSA/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/InternalHEXTwoUTube.mo
+++ b/IBPSA/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/InternalHEXTwoUTube.mo
@@ -19,7 +19,7 @@ model InternalHEXTwoUTube
     final tau4=VTubSeg*rho4_nominal/m4_flow_nominal,
     vol1(
       final energyDynamics=energyDynamics,
-      final massDynamics=massDynamics,
+      final massDynamics=energyDynamics,
       final prescribedHeatFlowRate=false,
       final allowFlowReversal=allowFlowReversal1,
       final m_flow_small=m1_flow_small,
@@ -27,14 +27,14 @@ model InternalHEXTwoUTube
       final mSenFac=mSenFac),
     vol2(
       final energyDynamics=energyDynamics,
-      final massDynamics=massDynamics,
+      final massDynamics=energyDynamics,
       final prescribedHeatFlowRate=false,
       final m_flow_small=m2_flow_small,
       final V=VTubSeg,
       final mSenFac=mSenFac),
     vol3(
       final energyDynamics=energyDynamics,
-      final massDynamics=massDynamics,
+      final massDynamics=energyDynamics,
       final prescribedHeatFlowRate=false,
       final allowFlowReversal=allowFlowReversal3,
       final m_flow_small=m3_flow_small,
@@ -42,7 +42,7 @@ model InternalHEXTwoUTube
       final mSenFac=mSenFac),
     vol4(
       final energyDynamics=energyDynamics,
-      final massDynamics=massDynamics,
+      final massDynamics=energyDynamics,
       final prescribedHeatFlowRate=false,
       final m_flow_small=m4_flow_small,
       final V=VTubSeg,
@@ -253,6 +253,12 @@ International Journal Of Energy Research, 35:312-320, 2011.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 7, 2022, by Michael Wetter:<br/>
+Removed <code>massDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
 <li>
 July 10, 2018, by Alex Laferri&egrave;re:<br/>
 Updated documentation following major changes to the IBPSA.Fluid.HeatExchangers.Ground package.

--- a/IBPSA/Fluid/HeatExchangers/ActiveBeams/BaseClasses/Convector.mo
+++ b/IBPSA/Fluid/HeatExchangers/ActiveBeams/BaseClasses/Convector.mo
@@ -24,8 +24,8 @@ model Convector "Heat exchanger for the water stream"
     "Type of energy balance: dynamic (3 initialization options) or steady state"
     annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
   parameter Modelica.Fluid.Types.Dynamics massDynamics=energyDynamics
-    "Type of mass balance: dynamic (3 initialization options) or steady state"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
+    "Type of mass balance: dynamic (3 initialization options) or steady state, must be steady state if energyDynamics is steady state"
+    annotation(Evaluate=true, Dialog(tab = "Advanced", group="Dynamics"));
 
   // Initialization
   parameter Medium.AbsolutePressure p_start = Medium.p_default
@@ -99,6 +99,11 @@ initial equation
     ": The constant homotopyInitialization has been modified from its default value. This constant will be removed in future releases.",
     level = AssertionLevel.warning);
 
+  assert(energyDynamics <> Modelica.Fluid.Types.Dynamics.SteadyState or
+         massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState,
+         "In " + getInstanceName() +
+         ": energyDynamics is selected as steady state, and therefore massDynamics must also be steady-state.");
+
 equation
   connect(hex.Q_flow, Q_flow) annotation (Line(points={{61,6},{70,6},{70,70},{
           110,70}},
@@ -153,6 +158,13 @@ In heating mode, the heat is removed from the water stream.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 3, 2022, by Michael Wetter:<br/>
+Moved <code>massDynamics</code> to <code>Advanced</code> tab and
+added assertion for correct combination of energy and mass dynamics.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">issue 1542</a>.
+</li>
 <li>
 April 14, 2020, by Michael Wetter:<br/>
 Changed <code>homotopyInitialization</code> to a constant.<br/>

--- a/IBPSA/Fluid/HeatExchangers/ActiveBeams/Cooling.mo
+++ b/IBPSA/Fluid/HeatExchangers/ActiveBeams/Cooling.mo
@@ -49,8 +49,8 @@ model Cooling "Active beam unit for cooling"
     "Type of energy balance: dynamic (3 initialization options) or steady state"
     annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
   parameter Modelica.Fluid.Types.Dynamics massDynamics=energyDynamics
-    "Type of mass balance: dynamic (3 initialization options) or steady state"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
+    "Type of mass balance: dynamic (3 initialization options) or steady state, must be steady state if energyDynamics is steady state"
+    annotation(Evaluate=true, Dialog(tab = "Advanced", group="Dynamics"));
 
   // Initialization
   parameter MediumWat.AbsolutePressure pWatCoo_start = MediumWat.p_default
@@ -194,6 +194,10 @@ initial equation
   assert(homotopyInitialization, "In " + getInstanceName() +
     ": The constant homotopyInitialization has been modified from its default value. This constant will be removed in future releases.",
     level = AssertionLevel.warning);
+  assert(energyDynamics <> Modelica.Fluid.Types.Dynamics.SteadyState or
+         massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState,
+         "In " + getInstanceName() +
+         ": energyDynamics is selected as steady state, and therefore massDynamics must also be steady-state.");
 
 equation
   connect(heaToRoo.port, heaPor)
@@ -298,6 +302,13 @@ DOE(2015) EnergyPlus documentation v8.4.0 - Engineering Reference.
 </ul>
 </html>", revisions="<html>
 <ul>
+<li>
+March 3, 2022, by Michael Wetter:<br/>
+Moved <code>massDynamics</code> to <code>Advanced</code> tab and
+added assertion for correct combination of energy and mass dynamics.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">issue 1542</a>.
+</li>
 <li>
 March 30, 2021, by Michael Wetter:<br/>
 Added annotation <code>HideResult=true</code>.<br/>

--- a/IBPSA/Fluid/HeatExchangers/EvaporatorCondenser.mo
+++ b/IBPSA/Fluid/HeatExchangers/EvaporatorCondenser.mo
@@ -118,6 +118,12 @@ throughout the heat exchanger.
 revisions="<html>
 <ul>
 <li>
+March 7, 2022, by Michael Wetter:<br/>
+Removed <code>massDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
+<li>
 May 27, 2017, by Filip Jorissen:<br/>
 Regularised heat transfer around zero flow.<br/>
 This is for

--- a/IBPSA/Fluid/HeatExchangers/HeaterCooler_u.mo
+++ b/IBPSA/Fluid/HeatExchangers/HeaterCooler_u.mo
@@ -117,6 +117,12 @@ IBPSA.Fluid.HeatExchangers.Validation.HeaterCooler_u</a>.
 revisions="<html>
 <ul>
 <li>
+March 7, 2022, by Michael Wetter:<br/>
+Removed <code>massDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
+<li>
 November 3, 2016, by Michael Wetter:<br/>
 Set <code>preHea(final alpha=0)</code> as this allows to simplify the
 system of equations.<br/>

--- a/IBPSA/Fluid/HeatExchangers/PrescribedOutlet.mo
+++ b/IBPSA/Fluid/HeatExchangers/PrescribedOutlet.mo
@@ -12,7 +12,7 @@ model PrescribedOutlet
       final mWatMax_flow = mWatMax_flow,
       final mWatMin_flow = mWatMin_flow,
       final energyDynamics = energyDynamics,
-      final massDynamics = massDynamics));
+      final massDynamics = energyDynamics));
 
   parameter Modelica.Units.SI.HeatFlowRate QMax_flow(min=0) = Modelica.Constants.inf
     "Maximum heat flow rate for heating (positive)"
@@ -39,10 +39,6 @@ model PrescribedOutlet
   parameter Modelica.Fluid.Types.Dynamics energyDynamics = Modelica.Fluid.Types.Dynamics.SteadyState
     "Type of energy balance: dynamic (3 initialization options) or steady state"
     annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations", enable=use_TSet));
-
-  parameter Modelica.Fluid.Types.Dynamics massDynamics=energyDynamics
-    "Type of mass balance: dynamic (3 initialization options) or steady state, must be steady state if energyDynamics is steady state"
-    annotation(Evaluate=true, Dialog(tab = "Advanced", group="Dynamics", enable=use_X_wSet));
 
   parameter Boolean use_TSet = true
     "Set to false to disable temperature set point"
@@ -71,12 +67,6 @@ model PrescribedOutlet
   Modelica.Blocks.Interfaces.RealOutput mWat_flow(unit="kg/s")
     "Water vapor mass flow rate added to the fluid (if flow is from port_a to port_b)"
     annotation (Placement(transformation(extent={{100,30},{120,50}})));
-
-initial equation
-  assert(energyDynamics <> Modelica.Fluid.Types.Dynamics.SteadyState or
-         massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState,
-         "In " + getInstanceName() +
-         ": energyDynamics is selected as steady state, and therefore massDynamics must also be steady-state.");
 
 equation
   connect(outCon.X_wSet, X_wSet) annotation (Line(points={{19,4},{-20,4},{-20,
@@ -245,8 +235,7 @@ revisions="<html>
 <ul>
 <li>
 March 3, 2022, by Michael Wetter:<br/>
-Moved <code>massDynamics</code> to <code>Advanced</code> tab and
-added assertion for correct combination of energy and mass dynamics.<br/>
+Removed <code>massDynamics</code>.<br/>
 This is for
 <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">issue 1542</a>.
 </li>

--- a/IBPSA/Fluid/HeatExchangers/PrescribedOutlet.mo
+++ b/IBPSA/Fluid/HeatExchangers/PrescribedOutlet.mo
@@ -40,9 +40,9 @@ model PrescribedOutlet
     "Type of energy balance: dynamic (3 initialization options) or steady state"
     annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations", enable=use_TSet));
 
-  parameter Modelica.Fluid.Types.Dynamics massDynamics = energyDynamics
-    "Type of mass balance: dynamic (3 initialization options) or steady state"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations", enable=use_X_wSet));
+  parameter Modelica.Fluid.Types.Dynamics massDynamics=energyDynamics
+    "Type of mass balance: dynamic (3 initialization options) or steady state, must be steady state if energyDynamics is steady state"
+    annotation(Evaluate=true, Dialog(tab = "Advanced", group="Dynamics", enable=use_X_wSet));
 
   parameter Boolean use_TSet = true
     "Set to false to disable temperature set point"
@@ -71,6 +71,12 @@ model PrescribedOutlet
   Modelica.Blocks.Interfaces.RealOutput mWat_flow(unit="kg/s")
     "Water vapor mass flow rate added to the fluid (if flow is from port_a to port_b)"
     annotation (Placement(transformation(extent={{100,30},{120,50}})));
+
+initial equation
+  assert(energyDynamics <> Modelica.Fluid.Types.Dynamics.SteadyState or
+         massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState,
+         "In " + getInstanceName() +
+         ": energyDynamics is selected as steady state, and therefore massDynamics must also be steady-state.");
 
 equation
   connect(outCon.X_wSet, X_wSet) annotation (Line(points={{19,4},{-20,4},{-20,
@@ -237,6 +243,13 @@ IBPSA.Fluid.HeatExchangers.Validation.PrescribedOutlet_dynamic</a>.
 </html>",
 revisions="<html>
 <ul>
+<li>
+March 3, 2022, by Michael Wetter:<br/>
+Moved <code>massDynamics</code> to <code>Advanced</code> tab and
+added assertion for correct combination of energy and mass dynamics.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">issue 1542</a>.
+</li>
 <li>
 May 3, 2017, by Michael Wetter:<br/>
 Updated protected model for

--- a/IBPSA/Fluid/HeatExchangers/Radiators/RadiatorEN442_2.mo
+++ b/IBPSA/Fluid/HeatExchangers/Radiators/RadiatorEN442_2.mo
@@ -8,7 +8,8 @@ model RadiatorEN442_2 "Dynamic radiator for space heating"
      final C_start = fill(0, Medium.nC),
      final C_nominal = fill(1E-2, Medium.nC),
      final mSenFac = 1 + 500*mDry/(VWat*cp_nominal*Medium.density(
-        Medium.setState_pTX(Medium.p_default, Medium.T_default, Medium.X_default))));
+        Medium.setState_pTX(Medium.p_default, Medium.T_default, Medium.X_default))),
+     final massDynamics=energyDynamics);
 
   constant Boolean homotopyInitialization = true "= true, use homotopy method"
     annotation(HideResult=true);
@@ -51,8 +52,8 @@ model RadiatorEN442_2 "Dynamic radiator for space heating"
     "= true, use m_flow = f(dp) else dp = f(m_flow)"
     annotation (Evaluate=true, Dialog(tab="Advanced"));
 
-  parameter Modelica.Units.SI.PressureDifference dp_nominal(displayUnit="Pa")
-     = 0 "Pressure drop at nominal mass flow rate"
+  parameter Modelica.Units.SI.PressureDifference dp_nominal(displayUnit="Pa")=
+       0 "Pressure drop at nominal mass flow rate"
     annotation (Dialog(group="Nominal condition"));
   parameter Boolean linearized = false
     "= true, use linear relation between m_flow and dp for any flow rate"
@@ -234,13 +235,13 @@ equation
       points={{-28,-70},{-20,-70},{-20,-10},{-9,-10}},
       color={191,0,0}));
   connect(vol[nEle].ports[2], port_b) annotation (Line(
-      points={{3,5.55112e-16},{27.25,5.55112e-16},{27.25,1.11022e-15},{51.5,1.11022e-15},
-          {51.5,5.55112e-16},{100,5.55112e-16}},
+      points={{2,5.55112e-16},{27.25,5.55112e-16},{27.25,1.11022e-15},{51.5,
+          1.11022e-15},{51.5,5.55112e-16},{100,5.55112e-16}},
       color={0,127,255}));
   for i in 1:nEle-1 loop
     connect(vol[i].ports[2], vol[i+1].ports[1]) annotation (Line(
-        points={{3,5.55112e-16},{2,5.55112e-16},{2,1.11022e-15},{1,1.11022e-15},
-            {1,5.55112e-16},{-1,5.55112e-16}},
+        points={{2,5.55112e-16},{2,5.55112e-16},{2,1.11022e-15},{1,1.11022e-15},
+            {1,5.55112e-16},{0,5.55112e-16}},
         color={0,127,255}));
   end for;
   connect(QCon.y, preCon.Q_flow)                  annotation (Line(
@@ -270,7 +271,7 @@ equation
   connect(res.port_a, port_a) annotation (Line(points={{-60,0},{-80,0},{-100,0}},
                     color={0,127,255}));
   connect(res.port_b, vol[1].ports[1])
-    annotation (Line(points={{-40,0},{-1,0}},      color={0,127,255}));
+    annotation (Line(points={{-40,0},{0,0}},       color={0,127,255}));
   annotation ( Icon(graphics={
         Ellipse(
           extent={{-20,22},{20,-20}},
@@ -371,6 +372,12 @@ with one plate of water carying fluid, and a height of 0.42 meters.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 7, 2022, by Michael Wetter:<br/>
+Set <code>final massDynamics=energyDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
 <li>
 April 14, 2020, by Michael Wetter:<br/>
 Changed <code>homotopyInitialization</code> to a constant.<br/>

--- a/IBPSA/Fluid/HeatExchangers/WetCoilEffectivenessNTU.mo
+++ b/IBPSA/Fluid/HeatExchangers/WetCoilEffectivenessNTU.mo
@@ -53,8 +53,8 @@ model WetCoilEffectivenessNTU
     "Type of energy balance: dynamic (3 initialization options) or steady state"
     annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
   parameter Modelica.Fluid.Types.Dynamics massDynamics=energyDynamics
-    "Type of mass balance: dynamic (3 initialization options) or steady state"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
+    "Type of mass balance: dynamic (3 initialization options) or steady state, must be steady state if energyDynamics is steady state"
+    annotation(Evaluate=true, Dialog(tab = "Advanced", group="Dynamics"));
 
   Modelica.Units.SI.HeatFlowRate Q1_flow=-dryWetCalcs.QTot_flow
     "Heat input into water stream (positive if air is cooled)";
@@ -311,6 +311,12 @@ initial equation
       configuration <= con.CrossFlowStream1UnmixedStream2Mixed,
       "Invalid heat exchanger configuration.");
   end if;
+
+  assert(energyDynamics <> Modelica.Fluid.Types.Dynamics.SteadyState or
+         massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState,
+         "In " + getInstanceName() +
+         ": energyDynamics is selected as steady state, and therefore massDynamics must also be steady-state.");
+
 equation
   // Assign the flow regime for the given heat exchanger configuration and
   // mass flow rates
@@ -615,6 +621,13 @@ Fuzzy identification of systems and its applications to modeling and control.
 &nbsp;IEEE transactions on systems, man, and cybernetics, (1), pp.116-132.</p>
 </html>",                    revisions="<html>
 <ul>
+<li>
+March 3, 2022, by Michael Wetter:<br/>
+Moved <code>massDynamics</code> to <code>Advanced</code> tab and
+added assertion for correct combination of energy and mass dynamics.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">issue 1542</a>.
+</li>
 <li>
 November 2, 2021, by Michael Wetter:<br/>
 Corrected unit assignment during the model instantiation.<br/>

--- a/IBPSA/Fluid/Humidifiers/Humidifier_u.mo
+++ b/IBPSA/Fluid/Humidifiers/Humidifier_u.mo
@@ -137,6 +137,12 @@ is adiabatic. To change the enthalpy of the air, add heat flow to the connector
 revisions="<html>
 <ul>
 <li>
+March 7, 2022, by Michael Wetter:<br/>
+Removed <code>massDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
+<li>
 April 12, 2017, by Michael Wetter:<br/>
 Removed parameters <code>use_T_in</code> and <code>T</code>.
 This removes the optional specification of temperature through the parameter <code>T</code>

--- a/IBPSA/Fluid/Humidifiers/SprayAirWasher_X.mo
+++ b/IBPSA/Fluid/Humidifiers/SprayAirWasher_X.mo
@@ -26,8 +26,8 @@ model SprayAirWasher_X
 
   // Dynamics
   parameter Modelica.Fluid.Types.Dynamics massDynamics = Modelica.Fluid.Types.Dynamics.SteadyState
-    "Type of mass balance: dynamic (3 initialization options) or steady state, must be steady state if energyDynamics is steady state"
-    annotation(Evaluate=true, Dialog(tab = "Advanced", group="Dynamics"));
+    "Type of mass balance: dynamic (3 initialization options) or steady state"
+    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
 
   // Set maximum to a high value to avoid users mistakenly entering relative humidity.
   Modelica.Blocks.Interfaces.RealInput X_w(
@@ -54,12 +54,6 @@ protected
                            h = hLea,
                            X = port_b.Xi_outflow)) "Leaving air temperature"
     annotation (Placement(transformation(extent={{-10,10},{10,30}})));
-initial equation
-  assert(energyDynamics <> Modelica.Fluid.Types.Dynamics.SteadyState or
-         massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState,
-         "In " + getInstanceName() +
-         ": energyDynamics is selected as steady state, and therefore massDynamics must also be steady-state.");
-
 equation
   connect(X_w, outCon.X_wSet)
     annotation (Line(points={{-120,60},{-20,60},{-20,4},{19,4}},
@@ -197,13 +191,6 @@ is adiabatic.
 </html>",
 revisions="<html>
 <ul>
-<li>
-March 3, 2022, by Michael Wetter:<br/>
-Moved <code>massDynamics</code> to <code>Advanced</code> tab and
-added assertion for correct combination of energy and mass dynamics.<br/>
-This is for
-<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">issue 1542</a>.
-</li>
 <li>
 December 14, 2018, by Michael Wetter:<br/>
 Restricted base class for medium to one that implements

--- a/IBPSA/Fluid/Humidifiers/SprayAirWasher_X.mo
+++ b/IBPSA/Fluid/Humidifiers/SprayAirWasher_X.mo
@@ -26,8 +26,8 @@ model SprayAirWasher_X
 
   // Dynamics
   parameter Modelica.Fluid.Types.Dynamics massDynamics = Modelica.Fluid.Types.Dynamics.SteadyState
-    "Type of mass balance: dynamic (3 initialization options) or steady state"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
+    "Type of mass balance: dynamic (3 initialization options) or steady state, must be steady state if energyDynamics is steady state"
+    annotation(Evaluate=true, Dialog(tab = "Advanced", group="Dynamics"));
 
   // Set maximum to a high value to avoid users mistakenly entering relative humidity.
   Modelica.Blocks.Interfaces.RealInput X_w(
@@ -54,6 +54,12 @@ protected
                            h = hLea,
                            X = port_b.Xi_outflow)) "Leaving air temperature"
     annotation (Placement(transformation(extent={{-10,10},{10,30}})));
+initial equation
+  assert(energyDynamics <> Modelica.Fluid.Types.Dynamics.SteadyState or
+         massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState,
+         "In " + getInstanceName() +
+         ": energyDynamics is selected as steady state, and therefore massDynamics must also be steady-state.");
+
 equation
   connect(X_w, outCon.X_wSet)
     annotation (Line(points={{-120,60},{-20,60},{-20,4},{19,4}},
@@ -191,6 +197,13 @@ is adiabatic.
 </html>",
 revisions="<html>
 <ul>
+<li>
+March 3, 2022, by Michael Wetter:<br/>
+Moved <code>massDynamics</code> to <code>Advanced</code> tab and
+added assertion for correct combination of energy and mass dynamics.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">issue 1542</a>.
+</li>
 <li>
 December 14, 2018, by Michael Wetter:<br/>
 Restricted base class for medium to one that implements

--- a/IBPSA/Fluid/Humidifiers/SteamHumidifier_X.mo
+++ b/IBPSA/Fluid/Humidifiers/SteamHumidifier_X.mo
@@ -24,8 +24,8 @@ model SteamHumidifier_X
 
   // Dynamics
   parameter Modelica.Fluid.Types.Dynamics massDynamics = Modelica.Fluid.Types.Dynamics.SteadyState
-    "Type of mass balance: dynamic (3 initialization options) or steady state"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
+    "Type of mass balance: dynamic (3 initialization options) or steady state, must be steady state if energyDynamics is steady state"
+    annotation(Evaluate=true, Dialog(tab = "Advanced", group="Dynamics"));
 
   // Set maximum to a high value to avoid users mistakenly entering relative humidity.
   Modelica.Blocks.Interfaces.RealInput X_w(
@@ -56,6 +56,12 @@ protected
                            h = hLea,
                            X = port_b.Xi_outflow)) "Leaving air temperature"
     annotation (Placement(transformation(extent={{-10,10},{10,30}})));
+initial equation
+  assert(energyDynamics <> Modelica.Fluid.Types.Dynamics.SteadyState or
+         massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState,
+         "In " + getInstanceName() +
+         ": energyDynamics is selected as steady state, and therefore massDynamics must also be steady-state.");
+
 equation
   connect(X_w, outCon.X_wSet)
     annotation (Line(points={{-120,60},{-20,60},{-20,4},{19,4}},
@@ -262,6 +268,13 @@ The water vapor of the reverse flow is not affected by this model.
 </html>",
 revisions="<html>
 <ul>
+<li>
+March 3, 2022, by Michael Wetter:<br/>
+Moved <code>massDynamics</code> to <code>Advanced</code> tab and
+added assertion for correct combination of energy and mass dynamics.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">issue 1542</a>.
+</li>
 <li>
 May 10, 2017, by Michael Wetter:<br/>
 First implementation.

--- a/IBPSA/Fluid/Humidifiers/SteamHumidifier_X.mo
+++ b/IBPSA/Fluid/Humidifiers/SteamHumidifier_X.mo
@@ -24,8 +24,8 @@ model SteamHumidifier_X
 
   // Dynamics
   parameter Modelica.Fluid.Types.Dynamics massDynamics = Modelica.Fluid.Types.Dynamics.SteadyState
-    "Type of mass balance: dynamic (3 initialization options) or steady state, must be steady state if energyDynamics is steady state"
-    annotation(Evaluate=true, Dialog(tab = "Advanced", group="Dynamics"));
+    "Type of mass balance: dynamic (3 initialization options) or steady state"
+    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
 
   // Set maximum to a high value to avoid users mistakenly entering relative humidity.
   Modelica.Blocks.Interfaces.RealInput X_w(
@@ -56,12 +56,6 @@ protected
                            h = hLea,
                            X = port_b.Xi_outflow)) "Leaving air temperature"
     annotation (Placement(transformation(extent={{-10,10},{10,30}})));
-initial equation
-  assert(energyDynamics <> Modelica.Fluid.Types.Dynamics.SteadyState or
-         massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState,
-         "In " + getInstanceName() +
-         ": energyDynamics is selected as steady state, and therefore massDynamics must also be steady-state.");
-
 equation
   connect(X_w, outCon.X_wSet)
     annotation (Line(points={{-120,60},{-20,60},{-20,4},{19,4}},
@@ -268,13 +262,6 @@ The water vapor of the reverse flow is not affected by this model.
 </html>",
 revisions="<html>
 <ul>
-<li>
-March 3, 2022, by Michael Wetter:<br/>
-Moved <code>massDynamics</code> to <code>Advanced</code> tab and
-added assertion for correct combination of energy and mass dynamics.<br/>
-This is for
-<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">issue 1542</a>.
-</li>
 <li>
 May 10, 2017, by Michael Wetter:<br/>
 First implementation.

--- a/IBPSA/Fluid/Interfaces/EightPortHeatMassExchanger.mo
+++ b/IBPSA/Fluid/Interfaces/EightPortHeatMassExchanger.mo
@@ -30,9 +30,6 @@ model EightPortHeatMassExchanger
   parameter Modelica.Fluid.Types.Dynamics energyDynamics=Modelica.Fluid.Types.Dynamics.DynamicFreeInitial
     "Formulation of energy balance"
     annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
-  parameter Modelica.Fluid.Types.Dynamics massDynamics=energyDynamics
-    "Formulation of mass balance"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
 
   // Initialization
   parameter Medium1.AbsolutePressure p1_start = Medium1.p_default
@@ -125,7 +122,7 @@ model EightPortHeatMassExchanger
                          then energyDynamics else
                          Modelica.Fluid.Types.Dynamics.SteadyState,
     massDynamics=if tau1 > Modelica.Constants.eps
-                         then massDynamics else
+                         then energyDynamics else
                          Modelica.Fluid.Types.Dynamics.SteadyState,
     final p_start=p1_start,
     final T_start=T1_start,
@@ -142,7 +139,7 @@ model EightPortHeatMassExchanger
                          then energyDynamics else
                          Modelica.Fluid.Types.Dynamics.SteadyState,
     massDynamics=if tau2 > Modelica.Constants.eps
-                         then massDynamics else
+                         then energyDynamics else
                          Modelica.Fluid.Types.Dynamics.SteadyState,
     final p_start=p2_start,
     final T_start=T2_start,
@@ -160,7 +157,7 @@ model EightPortHeatMassExchanger
                          then energyDynamics else
                          Modelica.Fluid.Types.Dynamics.SteadyState,
     massDynamics=if tau3 > Modelica.Constants.eps
-                         then massDynamics else
+                         then energyDynamics else
                          Modelica.Fluid.Types.Dynamics.SteadyState,
     final p_start=p3_start,
     final T_start=T3_start,
@@ -181,7 +178,7 @@ model EightPortHeatMassExchanger
                          then energyDynamics else
                          Modelica.Fluid.Types.Dynamics.SteadyState,
     massDynamics=if tau4 > Modelica.Constants.eps
-                         then massDynamics else
+                         then energyDynamics else
                          Modelica.Fluid.Types.Dynamics.SteadyState,
     final p_start=p4_start,
     final T_start=T4_start,
@@ -285,22 +282,12 @@ initial algorithm
 "The parameter tau1, or the volume of the model from which tau may be derived, is unreasonably small.
  You need to set energyDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
  Received tau1 = " + String(tau1) + "\n");
-  assert((massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState) or
-          tau1 > Modelica.Constants.eps,
-"The parameter tau1, or the volume of the model from which tau may be derived, is unreasonably small.
- You need to set massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
- Received tau1 = " + String(tau1) + "\n");
 
  // Check for tau2
   assert((energyDynamics == Modelica.Fluid.Types.Dynamics.SteadyState) or
           tau2 > Modelica.Constants.eps,
 "The parameter tau2, or the volume of the model from which tau may be derived, is unreasonably small.
  You need to set energyDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
- Received tau2 = " + String(tau2) + "\n");
-  assert((massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState) or
-          tau2 > Modelica.Constants.eps,
-"The parameter tau2, or the volume of the model from which tau may be derived, is unreasonably small.
- You need to set massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
  Received tau2 = " + String(tau2) + "\n");
 
   // Check for tau1
@@ -309,22 +296,12 @@ initial algorithm
 "The parameter tau3, or the volume of the model from which tau may be derived, is unreasonably small.
  You need to set energyDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
  Received tau3 = " + String(tau3) + "\n");
-  assert((massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState) or
-          tau3 > Modelica.Constants.eps,
-"The parameter tau3, or the volume of the model from which tau may be derived, is unreasonably small.
- You need to set massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
- Received tau3 = " + String(tau3) + "\n");
 
  // Check for tau2
   assert((energyDynamics == Modelica.Fluid.Types.Dynamics.SteadyState) or
           tau4 > Modelica.Constants.eps,
 "The parameter tau4, or the volume of the model from which tau may be derived, is unreasonably small.
  You need to set energyDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
- Received tau4 = " + String(tau4) + "\n");
-  assert((massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState) or
-          tau4 > Modelica.Constants.eps,
-"The parameter tau4, or the volume of the model from which tau may be derived, is unreasonably small.
- You need to set massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
  Received tau4 = " + String(tau4) + "\n");
 
   assert(homotopyInitialization, "In " + getInstanceName() +
@@ -333,7 +310,7 @@ initial algorithm
 
 equation
   connect(vol1.ports[2], port_b1) annotation (Line(
-      points={{2,80},{100,80}},
+      points={{1,80},{100,80}},
       color={0,127,255},
       smooth=Smooth.None));
   connect(port_a1, preDro1.port_a) annotation (Line(
@@ -341,7 +318,7 @@ equation
       color={0,127,255},
       smooth=Smooth.None));
   connect(preDro1.port_b, vol1.ports[1]) annotation (Line(
-      points={{-60,80},{-2,80}},
+      points={{-60,80},{-1,80}},
       color={0,127,255},
       smooth=Smooth.None));
   connect(port_a2, preDro2.port_a) annotation (Line(
@@ -353,11 +330,11 @@ equation
       color={0,127,255},
       smooth=Smooth.None));
   connect(preDro4.port_b, vol4.ports[1]) annotation (Line(
-      points={{66,-80},{-58,-80},{-58,-10}},
+      points={{66,-80},{-59,-80},{-59,-10}},
       color={0,127,255},
       smooth=Smooth.None));
   connect(port_b4, vol4.ports[2]) annotation (Line(
-      points={{-100,-80},{-62,-80},{-62,-10}},
+      points={{-100,-80},{-61,-80},{-61,-10}},
       color={0,127,255},
       smooth=Smooth.None));
   connect(port_a3, preDro3.port_a) annotation (Line(
@@ -365,19 +342,19 @@ equation
       color={0,127,255},
       smooth=Smooth.None));
   connect(preDro3.port_b, vol3.ports[1]) annotation (Line(
-      points={{-70,-32},{-54,-32},{-54,-76},{-2,-76},{-2,-70}},
+      points={{-70,-32},{-54,-32},{-54,-76},{-1,-76},{-1,-70}},
       color={0,127,255},
       smooth=Smooth.None));
   connect(port_b3, vol3.ports[2]) annotation (Line(
-      points={{100,-30},{90,-30},{90,-66},{62,-66},{62,-76},{2,-76},{2,-70}},
+      points={{100,-30},{90,-30},{90,-66},{62,-66},{62,-76},{1,-76},{1,-70}},
       color={0,127,255},
       smooth=Smooth.None));
   connect(port_b2, vol2.ports[1]) annotation (Line(
-      points={{-100,30},{58,30},{58,10}},
+      points={{-100,30},{59,30},{59,10}},
       color={0,127,255},
       smooth=Smooth.None));
   connect(preDro2.port_b, vol2.ports[2]) annotation (Line(
-      points={{70,30},{62,30},{62,10}},
+      points={{70,30},{61,30},{61,10}},
       color={0,127,255},
       smooth=Smooth.None));
   annotation (

--- a/IBPSA/Fluid/Interfaces/FourPortHeatMassExchanger.mo
+++ b/IBPSA/Fluid/Interfaces/FourPortHeatMassExchanger.mo
@@ -21,9 +21,6 @@ model FourPortHeatMassExchanger
   parameter Modelica.Fluid.Types.Dynamics energyDynamics=Modelica.Fluid.Types.Dynamics.DynamicFreeInitial
     "Type of energy balance: dynamic (3 initialization options) or steady state"
     annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
-  parameter Modelica.Fluid.Types.Dynamics massDynamics=energyDynamics
-    "Type of mass balance: dynamic (3 initialization options) or steady state, must be steady state if energyDynamics is steady state"
-    annotation(Evaluate=true, Dialog(tab = "Advanced", group="Dynamics"));
 
   // Initialization
   parameter Medium1.AbsolutePressure p1_start = Medium1.p_default
@@ -79,7 +76,7 @@ model FourPortHeatMassExchanger
                          then energyDynamics else
                          Modelica.Fluid.Types.Dynamics.SteadyState,
         massDynamics=if tau1 > Modelica.Constants.eps
-                         then massDynamics else
+                         then energyDynamics else
                          Modelica.Fluid.Types.Dynamics.SteadyState,
         final p_start=p1_start,
         final T_start=T1_start,
@@ -102,7 +99,7 @@ model FourPortHeatMassExchanger
                          then energyDynamics else
                          Modelica.Fluid.Types.Dynamics.SteadyState,
         massDynamics=if tau2 > Modelica.Constants.eps
-                         then massDynamics else
+                         then energyDynamics else
                          Modelica.Fluid.Types.Dynamics.SteadyState,
         final p_start=p2_start,
         final T_start=T2_start,
@@ -166,11 +163,6 @@ initial equation
 "The parameter tau1, or the volume of the model from which tau may be derived, is unreasonably small.
  You need to set energyDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
  Received tau1 = " + String(tau1) + "\n");
-  assert((massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState) or
-          tau1 > Modelica.Constants.eps,
-"The parameter tau1, or the volume of the model from which tau may be derived, is unreasonably small.
- You need to set massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
- Received tau1 = " + String(tau1) + "\n");
 
  // Check for tau2
   assert((energyDynamics == Modelica.Fluid.Types.Dynamics.SteadyState) or
@@ -178,17 +170,6 @@ initial equation
 "The parameter tau2, or the volume of the model from which tau may be derived, is unreasonably small.
  You need to set energyDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
  Received tau2 = " + String(tau2) + "\n");
-  assert((massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState) or
-          tau2 > Modelica.Constants.eps,
-"The parameter tau2, or the volume of the model from which tau may be derived, is unreasonably small.
- You need to set massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
- Received tau2 = " + String(tau2) + "\n");
-
-  assert(energyDynamics <> Modelica.Fluid.Types.Dynamics.SteadyState or
-         massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState,
-         "In " + getInstanceName() +
-         ": energyDynamics is selected as steady state, and therefore massDynamics must also be steady-state.");
-
 
   assert(homotopyInitialization, "In " + getInstanceName() +
     ": The constant homotopyInitialization has been modified from its default value. This constant will be removed in future releases.",
@@ -241,8 +222,7 @@ Modelica.Fluid.Examples.HeatExchanger.BaseClasses.BasicHX</a>.
 <ul>
 <li>
 March 3, 2022, by Michael Wetter:<br/>
-Moved <code>massDynamics</code> to <code>Advanced</code> tab,
-added assertion and changed type from <code>record</code> to <code>block</code>.<br/>
+Removed <code>massDynamics</code>.<br/>
 This is for
 <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">issue 1542</a>.
 </li>

--- a/IBPSA/Fluid/Interfaces/FourPortHeatMassExchanger.mo
+++ b/IBPSA/Fluid/Interfaces/FourPortHeatMassExchanger.mo
@@ -22,8 +22,8 @@ model FourPortHeatMassExchanger
     "Type of energy balance: dynamic (3 initialization options) or steady state"
     annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
   parameter Modelica.Fluid.Types.Dynamics massDynamics=energyDynamics
-    "Type of mass balance: dynamic (3 initialization options) or steady state"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
+    "Type of mass balance: dynamic (3 initialization options) or steady state, must be steady state if energyDynamics is steady state"
+    annotation(Evaluate=true, Dialog(tab = "Advanced", group="Dynamics"));
 
   // Initialization
   parameter Medium1.AbsolutePressure p1_start = Medium1.p_default
@@ -184,6 +184,12 @@ initial equation
  You need to set massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
  Received tau2 = " + String(tau2) + "\n");
 
+  assert(energyDynamics <> Modelica.Fluid.Types.Dynamics.SteadyState or
+         massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState,
+         "In " + getInstanceName() +
+         ": energyDynamics is selected as steady state, and therefore massDynamics must also be steady-state.");
+
+
   assert(homotopyInitialization, "In " + getInstanceName() +
     ": The constant homotopyInitialization has been modified from its default value. This constant will be removed in future releases.",
     level = AssertionLevel.warning);
@@ -233,6 +239,13 @@ Modelica.Fluid.Examples.HeatExchanger.BaseClasses.BasicHX</a>.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 3, 2022, by Michael Wetter:<br/>
+Moved <code>massDynamics</code> to <code>Advanced</code> tab,
+added assertion and changed type from <code>record</code> to <code>block</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">issue 1542</a>.
+</li>
 <li>
 April 14, 2020, by Michael Wetter:<br/>
 Changed <code>homotopyInitialization</code> to a constant.<br/>

--- a/IBPSA/Fluid/Interfaces/LumpedVolumeDeclarations.mo
+++ b/IBPSA/Fluid/Interfaces/LumpedVolumeDeclarations.mo
@@ -1,5 +1,5 @@
 within IBPSA.Fluid.Interfaces;
-record LumpedVolumeDeclarations "Declarations for lumped volumes"
+block LumpedVolumeDeclarations "Declarations for lumped volumes"
   replaceable package Medium =
     Modelica.Media.Interfaces.PartialMedium "Medium in the component"
       annotation (choices(
@@ -16,8 +16,8 @@ record LumpedVolumeDeclarations "Declarations for lumped volumes"
     "Type of energy balance: dynamic (3 initialization options) or steady state"
     annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
   parameter Modelica.Fluid.Types.Dynamics massDynamics=energyDynamics
-    "Type of mass balance: dynamic (3 initialization options) or steady state"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
+    "Type of mass balance: dynamic (3 initialization options) or steady state, must be steady state if energyDynamics is steady state"
+    annotation(Evaluate=true, Dialog(tab = "Advanced", group="Dynamics"));
   final parameter Modelica.Fluid.Types.Dynamics substanceDynamics=energyDynamics
     "Type of independent mass fraction balance: dynamic (3 initialization options) or steady state"
     annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
@@ -47,6 +47,11 @@ record LumpedVolumeDeclarations "Declarations for lumped volumes"
   parameter Real mSenFac(min=1)=1
     "Factor for scaling the sensible thermal mass of the volume"
     annotation(Dialog(tab="Dynamics"));
+initial equation
+  assert(energyDynamics <> Modelica.Fluid.Types.Dynamics.SteadyState or
+         massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState,
+         "In " + getInstanceName() +
+         ": energyDynamics is selected as steady state, and therefore massDynamics must also be steady-state.");
 
 annotation (preferredView="info",
 Documentation(info="<html>
@@ -67,6 +72,14 @@ IBPSA.Fluid.HeatExchangers.Radiators.RadiatorEN442_2</a>.
 </html>",
 revisions="<html>
 <ul>
+<li>
+March 3, 2022, by Michael Wetter:<br/>
+Moved <code>massDynamics</code> to <code>Advanced</code> tab,
+added assertion for correct combination of energy and mass dynamics and
+changed type from <code>record</code> to <code>block</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">issue 1542</a>.
+</li>
 <li>
 January 18, 2019, by Jianjun Hu:<br/>
 Limited the media choice.

--- a/IBPSA/Fluid/Interfaces/PrescribedOutlet.mo
+++ b/IBPSA/Fluid/Interfaces/PrescribedOutlet.mo
@@ -18,7 +18,7 @@ model PrescribedOutlet
     annotation (Evaluate=true, Dialog(enable=use_X_wSet));
 
   parameter Modelica.Units.SI.Time tau(min=0) = 10
-    "Time constant at nominal flow rate (used if energyDynamics or massDynamics not equal Modelica.Fluid.Types.Dynamics.SteadyState)"
+    "Time constant at nominal flow rate (used if energyDynamics not equal Modelica.Fluid.Types.Dynamics.SteadyState)"
     annotation (Dialog(tab="Dynamics"));
   parameter Modelica.Units.SI.Temperature T_start=Medium.T_default
     "Start value of temperature"
@@ -31,10 +31,6 @@ model PrescribedOutlet
   parameter Modelica.Fluid.Types.Dynamics energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState
     "Type of energy balance: dynamic (3 initialization options) or steady state"
     annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations", enable=use_TSet));
-
-  parameter Modelica.Fluid.Types.Dynamics massDynamics=energyDynamics
-    "Type of mass balance: dynamic (3 initialization options) or steady state, must be steady state if energyDynamics is steady state"
-    annotation(Evaluate=true, Dialog(tab = "Advanced", group="Dynamics", enable=use_X_wSet));
 
   parameter Boolean use_TSet = true
     "Set to false to disable temperature set point"
@@ -145,9 +141,9 @@ initial equation
   end if;
 
   if use_X_wSet then
-    if massDynamics == Modelica.Fluid.Types.Dynamics.SteadyStateInitial then
+    if energyDynamics == Modelica.Fluid.Types.Dynamics.SteadyStateInitial then
       der(Xi) = 0;
-    elseif massDynamics == Modelica.Fluid.Types.Dynamics.FixedInitial then
+    elseif energyDynamics == Modelica.Fluid.Types.Dynamics.FixedInitial then
       Xi = X_start[1];
     end if;
   end if;
@@ -156,11 +152,6 @@ initial equation
           tau > Modelica.Constants.eps,
 "The parameter tau, or the volume of the model from which tau may be derived, is unreasonably small.
  You need to set energyDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
- Received tau = " + String(tau) + "\n");
-  assert((massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState) or
-          tau > Modelica.Constants.eps,
-"The parameter tau, or the volume of the model from which tau may be derived, is unreasonably small.
- You need to set massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
  Received tau = " + String(tau) + "\n");
 
  if use_X_wSet then
@@ -178,8 +169,7 @@ equation
   end if;
   connect(X_wSet, X_wSet_internal);
 
-  if (use_TSet and energyDynamics == Modelica.Fluid.Types.Dynamics.SteadyState) or
-     (use_X_wSet and massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState) then
+  if ((use_TSet or use_X_wSet) and energyDynamics == Modelica.Fluid.Types.Dynamics.SteadyState) then
     mNor_flow = port_a.m_flow/m_flow_nominal;
     k = Modelica.Fluid.Utilities.regStep(x=port_a.m_flow,
                                          y1= mNor_flow,
@@ -196,7 +186,7 @@ equation
     T = TSet_internal;
   end if;
 
-  if use_X_wSet and massDynamics <> Modelica.Fluid.Types.Dynamics.SteadyState then
+  if use_X_wSet and energyDynamics <> Modelica.Fluid.Types.Dynamics.SteadyState then
     der(Xi) = (X_wSet_internal-Xi)*k/tau;
   else
     Xi = X_wSet_internal;
@@ -429,8 +419,7 @@ moisture mass flow rate.
 Also, optionally the model allows to take into account first order dynamics.
 </p>
 <p>
-If the parameters <code>energyDynamics</code> or
-<code>massDynamics</code> are not equal to
+If the parameters <code>energyDynamics</code> is not equal to
 <code>Modelica.Fluid.Types.Dynamics.SteadyState</code>,
 the component models the dynamic response using a first order differential equation.
 The time constant of the component is equal to the parameter <code>tau</code>.
@@ -463,8 +452,7 @@ properties as the fluid that enters <code>port_b</code>.
 <ul>
 <li>
 March 3, 2022, by Michael Wetter:<br/>
-Moved <code>massDynamics</code> to <code>Advanced</code> tab and
-added assertion for correct combination of energy and mass dynamics.<br/>
+Removed <code>massDynamics</code>.<br/>
 This is for
 <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">issue 1542</a>.
 </li>

--- a/IBPSA/Fluid/Interfaces/PrescribedOutlet.mo
+++ b/IBPSA/Fluid/Interfaces/PrescribedOutlet.mo
@@ -33,8 +33,8 @@ model PrescribedOutlet
     annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations", enable=use_TSet));
 
   parameter Modelica.Fluid.Types.Dynamics massDynamics=energyDynamics
-    "Type of mass balance: dynamic (3 initialization options) or steady state"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations", enable=use_X_wSet));
+    "Type of mass balance: dynamic (3 initialization options) or steady state, must be steady state if energyDynamics is steady state"
+    annotation(Evaluate=true, Dialog(tab = "Advanced", group="Dynamics", enable=use_X_wSet));
 
   parameter Boolean use_TSet = true
     "Set to false to disable temperature set point"
@@ -162,6 +162,11 @@ initial equation
 "The parameter tau, or the volume of the model from which tau may be derived, is unreasonably small.
  You need to set massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
  Received tau = " + String(tau) + "\n");
+
+  assert(energyDynamics <> Modelica.Fluid.Types.Dynamics.SteadyState or
+         massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState,
+         "In " + getInstanceName() +
+         ": energyDynamics is selected as steady state, and therefore massDynamics must also be steady-state.");
 
  if use_X_wSet then
   assert(Medium.nX > 1, "If use_X_wSet = true, require a medium with water vapor, such as IBPSA.Media.Air");
@@ -461,6 +466,13 @@ properties as the fluid that enters <code>port_b</code>.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 3, 2022, by Michael Wetter:<br/>
+Moved <code>massDynamics</code> to <code>Advanced</code> tab and
+added assertion for correct combination of energy and mass dynamics.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">issue 1542</a>.
+</li>
 <li>
 April 29, 2021, by Michael Wetter:<br/>
 Removed duplicate declaration of <code>m_flow_nominal</code> which is already

--- a/IBPSA/Fluid/Interfaces/PrescribedOutlet.mo
+++ b/IBPSA/Fluid/Interfaces/PrescribedOutlet.mo
@@ -163,11 +163,6 @@ initial equation
  You need to set massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
  Received tau = " + String(tau) + "\n");
 
-  assert(energyDynamics <> Modelica.Fluid.Types.Dynamics.SteadyState or
-         massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState,
-         "In " + getInstanceName() +
-         ": energyDynamics is selected as steady state, and therefore massDynamics must also be steady-state.");
-
  if use_X_wSet then
   assert(Medium.nX > 1, "If use_X_wSet = true, require a medium with water vapor, such as IBPSA.Media.Air");
  end if;

--- a/IBPSA/Fluid/Interfaces/TwoPortHeatMassExchanger.mo
+++ b/IBPSA/Fluid/Interfaces/TwoPortHeatMassExchanger.mo
@@ -18,9 +18,6 @@ model TwoPortHeatMassExchanger
   parameter Modelica.Fluid.Types.Dynamics energyDynamics=Modelica.Fluid.Types.Dynamics.DynamicFreeInitial
     "Type of energy balance: dynamic (3 initialization options) or steady state"
     annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
-  parameter Modelica.Fluid.Types.Dynamics massDynamics=energyDynamics
-    "Type of mass balance: dynamic (3 initialization options) or steady state, must be steady state if energyDynamics is steady state"
-    annotation(Evaluate=true, Dialog(tab = "Advanced", group="Dynamics"));
 
   // Initialization
   parameter Medium.AbsolutePressure p_start = Medium.p_default
@@ -47,7 +44,7 @@ model TwoPortHeatMassExchanger
     final mSenFac=1,
     final m_flow_nominal = m_flow_nominal,
     final energyDynamics=energyDynamics,
-    final massDynamics=massDynamics,
+    final massDynamics=energyDynamics,
     final p_start=p_start,
     final T_start=T_start,
     final X_start=X_start,
@@ -82,16 +79,6 @@ initial algorithm
 "The parameter tau, or the volume of the model from which tau may be derived, is unreasonably small.
  You need to set energyDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
  Received tau = " + String(tau) + "\n");
-  assert((massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState) or
-          tau > Modelica.Constants.eps,
-"The parameter tau, or the volume of the model from which tau may be derived, is unreasonably small.
- You need to set massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
- Received tau = " + String(tau) + "\n");
-
-  assert(energyDynamics <> Modelica.Fluid.Types.Dynamics.SteadyState or
-         massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState,
-         "In " + getInstanceName() +
-         ": energyDynamics is selected as steady state, and therefore massDynamics must also be steady-state.");
 
   assert(homotopyInitialization, "In " + getInstanceName() +
     ": The constant homotopyInitialization has been modified from its default value. This constant will be removed in future releases.",
@@ -150,8 +137,7 @@ Modelica.Fluid.Examples.HeatExchanger.BaseClasses.BasicHX
 <ul>
 <li>
 March 3, 2022, by Michael Wetter:<br/>
-Moved <code>massDynamics</code> to <code>Advanced</code> tab,
-added assertion and changed type from <code>record</code> to <code>block</code>.<br/>
+Removed <code>massDynamics</code>.<br/>
 This is for
 <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">issue 1542</a>.
 </li>

--- a/IBPSA/Fluid/Interfaces/TwoPortHeatMassExchanger.mo
+++ b/IBPSA/Fluid/Interfaces/TwoPortHeatMassExchanger.mo
@@ -19,8 +19,8 @@ model TwoPortHeatMassExchanger
     "Type of energy balance: dynamic (3 initialization options) or steady state"
     annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
   parameter Modelica.Fluid.Types.Dynamics massDynamics=energyDynamics
-    "Type of mass balance: dynamic (3 initialization options) or steady state"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
+    "Type of mass balance: dynamic (3 initialization options) or steady state, must be steady state if energyDynamics is steady state"
+    annotation(Evaluate=true, Dialog(tab = "Advanced", group="Dynamics"));
 
   // Initialization
   parameter Medium.AbsolutePressure p_start = Medium.p_default
@@ -88,6 +88,11 @@ initial algorithm
  You need to set massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState to model steady-state.
  Received tau = " + String(tau) + "\n");
 
+  assert(energyDynamics <> Modelica.Fluid.Types.Dynamics.SteadyState or
+         massDynamics == Modelica.Fluid.Types.Dynamics.SteadyState,
+         "In " + getInstanceName() +
+         ": energyDynamics is selected as steady state, and therefore massDynamics must also be steady-state.");
+
   assert(homotopyInitialization, "In " + getInstanceName() +
     ": The constant homotopyInitialization has been modified from its default value. This constant will be removed in future releases.",
     level = AssertionLevel.warning);
@@ -143,6 +148,13 @@ Modelica.Fluid.Examples.HeatExchanger.BaseClasses.BasicHX
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 3, 2022, by Michael Wetter:<br/>
+Moved <code>massDynamics</code> to <code>Advanced</code> tab,
+added assertion and changed type from <code>record</code> to <code>block</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">issue 1542</a>.
+</li>
 <li>
 April 14, 2020, by Michael Wetter:<br/>
 Changed <code>homotopyInitialization</code> to a constant.<br/>

--- a/IBPSA/Fluid/Interfaces/package.order
+++ b/IBPSA/Fluid/Interfaces/package.order
@@ -3,6 +3,7 @@ ConservationEquation
 EightPort
 EightPortHeatMassExchanger
 FourPortHeatMassExchanger
+LumpedVolumeDeclarations
 PartialEightPortInterface
 PartialFourPort
 PartialFourPortInterface
@@ -18,6 +19,5 @@ StaticTwoPortHeatMassExchanger
 TwoPortHeatMassExchanger
 EightPortFlowResistanceParameters
 FourPortFlowResistanceParameters
-LumpedVolumeDeclarations
 TwoPortFlowResistanceParameters
 Examples

--- a/IBPSA/Fluid/Movers/BaseClasses/PartialFlowMachine.mo
+++ b/IBPSA/Fluid/Movers/BaseClasses/PartialFlowMachine.mo
@@ -2,6 +2,7 @@ within IBPSA.Fluid.Movers.BaseClasses;
 partial model PartialFlowMachine
   "Partial model to interface fan or pump models with the medium"
   extends IBPSA.Fluid.Interfaces.LumpedVolumeDeclarations(
+    final massDynamics=energyDynamics,
     final mSenFac=1);
   extends IBPSA.Fluid.Interfaces.PartialTwoPortInterface(
     m_flow_nominal(final min=Modelica.Constants.small),

--- a/IBPSA/Fluid/Movers/FlowControlled_dp.mo
+++ b/IBPSA/Fluid/Movers/FlowControlled_dp.mo
@@ -165,6 +165,12 @@ IBPSA.Fluid.Movers.Validation.FlowControlled_dpSystem</a>.
       revisions="<html>
 <ul>
 <li>
+March 7, 2022, by Michael Wetter:<br/>
+Set <code>final massDynamics=energyDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
+<li>
 June 17, 2021, by Michael Wetter:<br/>
 Changed implementation of the filter.<br/>
 Removed parameter <code>y_start</code> which is not used because <code>dp_start</code> is used.<br/>

--- a/IBPSA/Fluid/Movers/FlowControlled_m_flow.mo
+++ b/IBPSA/Fluid/Movers/FlowControlled_m_flow.mo
@@ -114,6 +114,12 @@ User's Guide</a> for more information.
       revisions="<html>
 <ul>
 <li>
+March 7, 2022, by Michael Wetter:<br/>
+Set <code>final massDynamics=energyDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
+<li>
 June 17, 2021, by Michael Wetter:<br/>
 Changed implementation of the filter.<br/>
 Removed parameter <code>y_start</code> which is not used because <code>m_flow_start</code> is used.<br/>

--- a/IBPSA/Fluid/Movers/SpeedControlled_Nrpm.mo
+++ b/IBPSA/Fluid/Movers/SpeedControlled_Nrpm.mo
@@ -90,6 +90,12 @@ User's Guide</a> for more information.
       revisions="<html>
 <ul>
 <li>
+March 7, 2022, by Michael Wetter:<br/>
+Set <code>final massDynamics=energyDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
+<li>
 January 5, 2022, by Jianjun Hu:<br/>
 Changed the rotational speed unit to be consistent with the one in the Modelica Standard Library.<br/>
 This is for

--- a/IBPSA/Fluid/Movers/SpeedControlled_y.mo
+++ b/IBPSA/Fluid/Movers/SpeedControlled_y.mo
@@ -93,6 +93,12 @@ User's Guide</a> for more information.
       revisions="<html>
 <ul>
 <li>
+March 7, 2022, by Michael Wetter:<br/>
+Set <code>final massDynamics=energyDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
+<li>
 June 17, 2021, by Michael Wetter:<br/>
 Changed implementation of the filter.<br/>
 This is for

--- a/IBPSA/Fluid/Storage/BaseClasses/IndirectTankHeatExchanger.mo
+++ b/IBPSA/Fluid/Storage/BaseClasses/IndirectTankHeatExchanger.mo
@@ -9,7 +9,8 @@ model IndirectTankHeatExchanger
 
   extends IBPSA.Fluid.Interfaces.TwoPortFlowResistanceParameters;
   extends IBPSA.Fluid.Interfaces.LumpedVolumeDeclarations(
-      redeclare final package Medium = MediumHex);
+    final massDynamics=energyDynamics,
+    redeclare final package Medium = MediumHex);
   extends IBPSA.Fluid.Interfaces.PartialTwoPortInterface(
     redeclare final package Medium = MediumHex,
     final show_T=false);
@@ -47,9 +48,6 @@ model IndirectTankHeatExchanger
     annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
   parameter Modelica.Fluid.Types.Dynamics energyDynamicsSolid=energyDynamics
     "Formulation of energy balance for heat exchanger solid mass"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
-  parameter Modelica.Fluid.Types.Dynamics massDynamics=energyDynamics
-    "Formulation of mass balance for heat exchanger"
     annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
 
   parameter Boolean hA_flowDependent = true
@@ -299,6 +297,12 @@ equation
           </html>",
           revisions="<html>
 <ul>
+<li>
+March 7, 2022, by Michael Wetter:<br/>
+Set <code>final massDynamics=energyDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
 <li>
 April 9, 2021, by Michael Wetter:<br/>
 Corrected placement of <code>each</code> keyword.<br/>

--- a/IBPSA/Fluid/Storage/BaseClasses/PartialStratified.mo
+++ b/IBPSA/Fluid/Storage/BaseClasses/PartialStratified.mo
@@ -17,9 +17,6 @@ model PartialStratified
   parameter Types.Dynamics energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial
     "Formulation of energy balance"
     annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
-  parameter Types.Dynamics massDynamics=energyDynamics
-    "Formulation of mass balance"
-    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
 
   // Initialization
   parameter Medium.AbsolutePressure p_start = Medium.p_default
@@ -68,7 +65,7 @@ model PartialStratified
   IBPSA.Fluid.MixingVolumes.MixingVolume[nSeg] vol(
     redeclare each package Medium = Medium,
     each energyDynamics=energyDynamics,
-    each massDynamics=massDynamics,
+    each massDynamics=energyDynamics,
     each p_start=p_start,
     T_start=TFlu_start,
     each X_start=X_start,
@@ -207,6 +204,12 @@ IBPSA.Fluid.Storage.BaseClasses.ThirdOrderStratifier</a>.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 7, 2022, by Michael Wetter:<br/>
+Set <code>final massDynamics=energyDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
 <li>
 November 13, 2019 by Jianjun Hu:<br/>
 Added parameter <code>TFlu_start</code> and changed the initial tank segments

--- a/IBPSA/Fluid/Storage/Stratified.mo
+++ b/IBPSA/Fluid/Storage/Stratified.mo
@@ -40,6 +40,12 @@ IBPSA.Fluid.Storage.StratifiedEnhanced</a>.
 </html>", revisions="<html>
 <ul>
 <li>
+March 7, 2022, by Michael Wetter:<br/>
+Set <code>final massDynamics=energyDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
+<li>
 June 7, 2018 by Filip Jorissen:<br/>
 Copied model from Buildings and update the model accordingly.
 This is for

--- a/IBPSA/Fluid/Storage/StratifiedEnhanced.mo
+++ b/IBPSA/Fluid/Storage/StratifiedEnhanced.mo
@@ -95,6 +95,12 @@ The model requires at least 4 fluid segments. Hence, set <code>nSeg</code> to 4 
 </html>", revisions="<html>
 <ul>
 <li>
+March 7, 2022, by Michael Wetter:<br/>
+Set <code>final massDynamics=energyDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
+<li>
 June 7, 2018 by Filip Jorissen:<br/>
 Copied model from Buildings and update the model accordingly.
 This is for

--- a/IBPSA/Fluid/Storage/StratifiedEnhancedInternalHex.mo
+++ b/IBPSA/Fluid/Storage/StratifiedEnhancedInternalHex.mo
@@ -249,6 +249,12 @@ The model requires at least 4 fluid segments. Hence, set <code>nSeg</code> to 4 
 revisions="<html>
 <ul>
 <li>
+March 7, 2022, by Michael Wetter:<br/>
+Set <code>final massDynamics=energyDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
+<li>
 June 7, 2018 by Filip Jorissen:<br/>
 Copied model from Buildings and update the model accordingly.
 This is for

--- a/IBPSA/Fluid/package.mo
+++ b/IBPSA/Fluid/package.mo
@@ -158,7 +158,7 @@ In actuators such as valves and air dampers, <i>k</i> is a function of the contr
 
 <h4>Computation of mass and energy balance</h4>
 <p>
-Most models have parameters
+Some models have parameters
 <code>massDynamics</code> and <code>energyDynamics</code>
 that allow using a dynamic or a
 steady-state equation for the mass and energy balance.

--- a/IBPSA/Resources/Scripts/Dymola/ConvertIBPSA_from_3.0_to_4.0.mos
+++ b/IBPSA/Resources/Scripts/Dymola/ConvertIBPSA_from_3.0_to_4.0.mos
@@ -5,6 +5,34 @@ clear
 
 convertClear();
 
+// Conversion for https://github.com/ibpsa/modelica-ibpsa/issues/1542
+convertClass("IBPSA.Airflow.Multizone.MediumColumnDynamic", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.Fluid.Actuators.Valves.ThreeWayEqualPercentageLinear", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.Fluid.Actuators.Valves.ThreeWayLinear", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.Fluid.Actuators.Valves.ThreeWayTable", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.Fluid.HeatExchangers.Radiators.RadiatorEN442_2", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.Fluid.Movers.FlowControlled_dp", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.Fluid.Movers.FlowControlled_m_flow", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.Fluid.Movers.SpeedControlled_Nrpm", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.Fluid.Movers.SpeedControlled_y", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.Fluid.Storage.Stratified", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.Fluid.Storage.StratifiedEnhanced", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.Fluid.Storage.StratifiedEnhancedInternalHex", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.Fluid.HeatExchangers.EvaporatorCondenser", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.Fluid.HeatExchangers.HeaterCooler_u", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.Fluid.Humidifiers.Humidifier_u", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.Fluid.Interfaces.TwoPortHeatMassExchanger", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.Fluid.Geothermal.Borefields.BaseClasses.Boreholes.BaseClasses.InternalHEXOneUTube", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.Fluid.Geothermal.Borefields.BaseClasses.Boreholes.BaseClasses.InternalHEXTwoUTube", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.Fluid.HeatExchangers.PrescribedOutlet", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.Fluid.Interfaces.PrescribedOutlet", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.ThermalZones.ReducedOrder.RC.FourElements", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.ThermalZones.ReducedOrder.RC.OneElement", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.ThermalZones.ReducedOrder.RC.ThreeElements", {"massDynamics"}, fill("",0), true);
+convertClass("IBPSA.ThermalZones.ReducedOrder.RC.TwoElements", {"massDynamics"}, fill("",0), true);
+
+
+
 // Conversion for https://github.com/ibpsa/modelica-ibpsa/issues/1522
 convertClass("IBPSA.Controls.Continuous.PIDHysteresisTimer",
              "IBPSA.Obsolete.Controls.Continuous.PIDHysteresisTimer");
@@ -16,7 +44,7 @@ convertModifiers("IBPSA.BoundaryConditions.SolarGeometry.IncidenceAngle", {"lat"
 convertModifiers("IBPSA.BoundaryConditions.SolarGeometry.BaseClasses.IncidenceAngle", {"lat"}, fill("",0), true);
 convertModifiers("IBPSA.BoundaryConditions.SolarGeometry.ZenithAngle", {"lat"}, fill("",0), true);
 convertModifiers("IBPSA.BoundaryConditions.SolarIrradiation.DiffusePerez", {"lat"}, fill("",0), true);
-convertModifiers("IBPSA.BoundaryConditions.SolarIrradiation.DirectTiltedSurface", {"lat"}, fill("",0), true);
+convertModifiers("IBPSA.BoundaryConditions.SolarIrradiation.DirectTiltedSurface", {"lat"}, fill("",0), true);IBPSA.Fluid.Actuators.Valves.TwoWayButterfly
 
 // Refactoring for https://github.com/ibpsa/modelica-ibpsa/issues/1494
 convertClass("IBPSA.Fluid.FixedResistances.PlugFlowPipe",

--- a/IBPSA/ThermalZones/ReducedOrder/RC/FourElements.mo
+++ b/IBPSA/ThermalZones/ReducedOrder/RC/FourElements.mo
@@ -193,29 +193,35 @@ equation
   textColor={0,0,0},
   textString="4")}),
   Documentation(revisions="<html>
-  <ul>
-  <li>
-  December 9, 2019, by Moritz Lauster:<br/>
-  Changes <code>nExt</code> to <code>nRoof</code> for
-  <code>RRoof</code> and <code>CRoof</code>
-  </li>
-  <li>
-  July 11, 2019, by Katharina Brinkmann:<br/>
-  Renamed <code>alphaRoof</code> to <code>hConRoof</code>,
-  <code>alphaRoofConst</code> to <code>hConRoof_const</code>
-  </li>
-  <li>
-  August 31, 2018 by Moritz Lauster:<br/>
-  Updated schema in documentation and fixes
-  orientation and connections of roofRC for
-  <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/997\">
-  issue 997</a>.
-  </li>
-  <li>
-  September 11, 2015 by Moritz Lauster:<br/>
-  First Implementation.
-  </li>
-  </ul>
+<ul>
+<li>
+March 7, 2022, by Michael Wetter:<br/>
+Removed <code>massDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
+<li>
+December 9, 2019, by Moritz Lauster:<br/>
+Changes <code>nExt</code> to <code>nRoof</code> for
+<code>RRoof</code> and <code>CRoof</code>
+</li>
+<li>
+July 11, 2019, by Katharina Brinkmann:<br/>
+Renamed <code>alphaRoof</code> to <code>hConRoof</code>,
+<code>alphaRoofConst</code> to <code>hConRoof_const</code>
+</li>
+<li>
+August 31, 2018 by Moritz Lauster:<br/>
+Updated schema in documentation and fixes
+orientation and connections of roofRC for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/997\">
+issue 997</a>.
+</li>
+<li>
+September 11, 2015 by Moritz Lauster:<br/>
+First Implementation.
+</li>
+</ul>
 </html>",   info="<html>
   <p>
   This model adds another element for the roof. Roofs commonly

--- a/IBPSA/ThermalZones/ReducedOrder/RC/OneElement.mo
+++ b/IBPSA/ThermalZones/ReducedOrder/RC/OneElement.mo
@@ -1,6 +1,7 @@
 within IBPSA.ThermalZones.ReducedOrder.RC;
 model OneElement "Thermal Zone with one element for exterior walls"
-  extends IBPSA.Fluid.Interfaces.LumpedVolumeDeclarations;
+  extends IBPSA.Fluid.Interfaces.LumpedVolumeDeclarations(
+    final massDynamics=energyDynamics);
 
   parameter Modelica.Units.SI.Volume VAir "Air volume of the zone"
     annotation (Dialog(group="Thermal zone"));
@@ -539,6 +540,12 @@ The image below shows the RC-network of this model.
   </html>",
 revisions="<html>
 <ul>
+<li>
+March 7, 2022, by Michael Wetter:<br/>
+Removed <code>massDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
 <li>
 October 9, 2019, by Michael Wetter:<br/>
 Refactored addition of moisture to also account for the energy content of the

--- a/IBPSA/ThermalZones/ReducedOrder/RC/ThreeElements.mo
+++ b/IBPSA/ThermalZones/ReducedOrder/RC/ThreeElements.mo
@@ -178,28 +178,34 @@ equation
     textColor={0,0,0},
     textString="3")}),
     Documentation(revisions="<html>
-  <ul>
-  <li>
-  December 9, 2019, by Moritz Lauster:<br/>
-  Changes <code>nExt</code> to <code>nFloor</code> for
-  <code>RFloor</code> and <code>CFloor</code>
-  </li>
-  <li>
-  July 11, 2019, by Katharina Brinkmann:<br/>
-  Renamed <code>alphaFloor</code> to <code>hConFloor</code>,
-  <code>alphaFloorConst</code> to <code>hConFloor_const</code>
-  </li>
-  <li>
-  August 31, 2018 by Moritz Lauster:<br/>
-  Updated schema in documentation to fix
-  <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/997\">
-  issue 997</a>.
-  </li>
-  <li>
-  July 15, 2015 by Moritz Lauster:<br/>
-  First Implementation.
-  </li>
-  </ul>
+<ul>
+<li>
+March 7, 2022, by Michael Wetter:<br/>
+Removed <code>massDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
+<li>
+December 9, 2019, by Moritz Lauster:<br/>
+Changes <code>nExt</code> to <code>nFloor</code> for
+<code>RFloor</code> and <code>CFloor</code>
+</li>
+<li>
+July 11, 2019, by Katharina Brinkmann:<br/>
+Renamed <code>alphaFloor</code> to <code>hConFloor</code>,
+<code>alphaFloorConst</code> to <code>hConFloor_const</code>
+</li>
+<li>
+August 31, 2018 by Moritz Lauster:<br/>
+Updated schema in documentation to fix
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/997\">
+issue 997</a>.
+</li>
+<li>
+July 15, 2015 by Moritz Lauster:<br/>
+First Implementation.
+</li>
+</ul>
 </html>",   info="<html>
   <p>This model adds one further element for
   the floor plate. Long-term effects dominate the excitation of the floor plate

--- a/IBPSA/ThermalZones/ReducedOrder/RC/TwoElements.mo
+++ b/IBPSA/ThermalZones/ReducedOrder/RC/TwoElements.mo
@@ -124,21 +124,27 @@ equation
     fillColor={215,215,215},
     fillPattern=FillPattern.Solid,
     textString="Interior Walls")}), Documentation(revisions="<html>
-  <ul>
-  <li>
-  July 11, 2019, by Katharina Brinkmann:<br/>
-  Renamed <code>alphaInt</code> to <code>hConInt</code>,
-  <code>alphaIntWall</code> to <code>hConIntWall</code>
-  </li>
-  <li>
-  January 25, 2019, by Michael Wetter:<br/>
-  Added start value to avoid warning in JModelica.
-  </li>
-  <li>
-  April 18, 2015, by Moritz Lauster:<br/>
-  First implementation.
-  </li>
-  </ul>
+<ul>
+<li>
+March 7, 2022, by Michael Wetter:<br/>
+Removed <code>massDynamics</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1542\">#1542</a>.
+</li>
+<li>
+July 11, 2019, by Katharina Brinkmann:<br/>
+Renamed <code>alphaInt</code> to <code>hConInt</code>,
+<code>alphaIntWall</code> to <code>hConIntWall</code>
+</li>
+<li>
+January 25, 2019, by Michael Wetter:<br/>
+Added start value to avoid warning in JModelica.
+</li>
+<li>
+April 18, 2015, by Moritz Lauster:<br/>
+First implementation.
+</li>
+</ul>
 </html>",   info="<html>
   <p>This model distinguishes between internal
   thermal masses and exterior walls. While exterior walls contribute to heat


### PR DESCRIPTION
This closes #1542 

This is based on https://github.com/ibpsa/modelica-ibpsa/pull/1589 and makes massDynamics final, or removes it, except in the MixingVolume.
This is to address https://github.com/ibpsa/modelica-ibpsa/issues/1542#issuecomment-1059329392