### PR TITLE
Added missing header file inclusion

### DIFF
--- a/IBPSA/Resources/C-Sources/jsonWriterInit.c
+++ b/IBPSA/Resources/C-Sources/jsonWriterInit.c
@@ -5,8 +5,10 @@
  * Filip Jorissen, KU Leuven
  */
 
-#include "jsonWriterInit.h"
 #include "fileWriterStructure.c"
+#include "ModelicaUtilities.h"
+
+#include "jsonWriterInit.h"
 
 void* jsonWriterInit(
   const char* instanceName,


### PR DESCRIPTION
This is required because the C code calls ModelicaFormatError which is defined in the missing header file