### PR TITLE
der_spliceFunction check limits

### DIFF
--- a/IBPSA/Utilities/Math/Functions/BaseClasses/der_spliceFunction.mo
+++ b/IBPSA/Utilities/Math/Functions/BaseClasses/der_spliceFunction.mo
@@ -48,6 +48,11 @@ IBPSA.Utilities.Math.Functions.spliceFunction</a>.
 revisions="<html>
 <ul>
 <li>
+September 27, 2022, by Matthis Thorade:<br/>
+Changed limits.<br/>
+This is for <a href=\"https://github.com/ibpsa/modelica-ibpsa/pull/1640\">IBPSA, issue #1640</a>.
+</li>
+<li>
 October 13, 2021, by Michael Wetter:<br/>
 Changed implementation to not use <code>cosh</code> which overflows around <i>800</i>.<br/>
 This is for

--- a/IBPSA/Utilities/Math/Functions/BaseClasses/der_spliceFunction.mo
+++ b/IBPSA/Utilities/Math/Functions/BaseClasses/der_spliceFunction.mo
@@ -11,6 +11,7 @@ function der_spliceFunction "Derivative of splice function"
   input Real ddeltax=0;
   output Real out;
 protected
+  constant Real lim = 0.9999999999 "Limit in criterion for smoothing range";
   Real scaledX1 "x scaled to -1 ... 1 interval";
   Real scaledXp "x scaled to -pi/2 ... pi/2 interval";
   Real scaledXt "x scaled to -inf ... inf interval";
@@ -18,9 +19,9 @@ protected
   Real y;
 algorithm
   scaledX1 := x/deltax;
-  if scaledX1 <= -0.9999999999 then
+  if scaledX1 <= -lim then
     y := 0.0;
-  elseif scaledX1 >= 0.9999999999 then
+  elseif scaledX1 >= lim then
     y := 1.0;
   else
     scaledXp := scaledX1*0.5*Modelica.Constants.pi;
@@ -29,7 +30,7 @@ algorithm
   end if;
   out := dpos*y + (1 - y)*dneg;
 
-  if (abs(scaledX1) < 1) then
+  if (abs(scaledX1) < lim) then
     dscaledX1 := (dx - scaledX1*ddeltax)/deltax;
     out := out + (pos - neg)*dscaledX1*0.25*Modelica.Constants.pi*(1 - Modelica.Math.tanh(scaledXt)^2)*(scaledXt^2 + 1);
   end if;

--- a/IBPSA/Utilities/Math/Functions/spliceFunction.mo
+++ b/IBPSA/Utilities/Math/Functions/spliceFunction.mo
@@ -38,6 +38,11 @@ for easier accessability to model developers.
 </html>", revisions="<html>
 <ul>
 <li>
+September 27, 2022, by Matthis Thorade:<br/>
+Changed limits.<br/>
+This is for <a href=\"https://github.com/ibpsa/modelica-ibpsa/pull/1640\">IBPSA, issue #1640</a>.
+</li>
+<li>
 May 10, 2013, by Michael Wetter:<br/>
 Reformulated implementation to avoid unrequired computations.
 </li>

--- a/IBPSA/Utilities/Math/Functions/spliceFunction.mo
+++ b/IBPSA/Utilities/Math/Functions/spliceFunction.mo
@@ -7,14 +7,15 @@ function spliceFunction
     input Real deltax "Half width of transition interval";
     output Real out "Smoothed value";
 protected
+    constant Real lim = 0.9999999999;
     Real scaledX1;
     Real y;
     constant Real asin1 = Modelica.Math.asin(1);
 algorithm
     scaledX1 := x/deltax;
-    if scaledX1 <= -0.999999999 then
+    if scaledX1 <= -lim then
       out := neg;
-    elseif scaledX1 >= 0.999999999 then
+    elseif scaledX1 >= lim then
       out := pos;
     else
       y := (Modelica.Math.tanh(Modelica.Math.tan(scaledX1*asin1)) + 1)/2;


### PR DESCRIPTION
this is a follow-up for #1531 and #1532
there are two if-conditions that used a different value: 1 versus 0.9999999999
this PR makes sure the identical limit is used in
spliceFunction and corresponding derivative

This integrates https://github.com/ibpsa/modelica-ibpsa/pull/1640