### PR TITLE
Avoided state event where time event can be generated

### DIFF
--- a/IBPSA/Media/Examples/BaseClasses/TestTemperatureEnthalpyInversion.mo
+++ b/IBPSA/Media/Examples/BaseClasses/TestTemperatureEnthalpyInversion.mo
@@ -11,7 +11,7 @@ partial model TestTemperatureEnthalpyInversion
 equation
     h = Medium.specificEnthalpy_pTX(p=101325, T=T0, X=Xi);
     T = Medium.temperature_phX(p=101325, h=h,  X=Xi);
-    if (time>0.1) then
+    if (time>=0.1) then
     assert(abs(T-T0)<tol, "Error in implementation of functions.\n"
        + "   T0 = " + String(T0) + "\n"
        + "   T  = " + String(T) + "\n"
@@ -24,6 +24,12 @@ Hence, it checks whether the function <code>T_phX</code> is
 implemented correctly.
 </html>", revisions="<html>
 <ul>
+<li>
+November 14, 2022, by Michael Wetter:<br/>
+Reformulated <code>if</code>-expression to avoid warning about state event.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1657\">#1657</a>.
+</li>
 <li>
 March 24, 2020 by Kathryn Hinkelman:<br/>
 Expanded the assert message to include absolute error value.


### PR DESCRIPTION
This closes #1657.
It reformulates the if-expression to avoid a state event