### PR TITLE
Added missing annotation for medium selection in ISO13790 zone model

### DIFF
--- a/IBPSA/ThermalZones/ISO13790/Zone5R1C/ZoneHVAC.mo
+++ b/IBPSA/ThermalZones/ISO13790/Zone5R1C/ZoneHVAC.mo
@@ -1,7 +1,8 @@
 within IBPSA.ThermalZones.ISO13790.Zone5R1C;
 model ZoneHVAC "Thermal zone for HVAC based on 5R1C network"
   extends Zone(capMas(C=buiMas.heaC*AFlo - VRoo*1.2*1014));
-  replaceable package Medium = Modelica.Media.Interfaces.PartialMedium;
+  replaceable package Medium = Modelica.Media.Interfaces.PartialMedium annotation (
+        choices(choice(redeclare package Medium = IBPSA.Media.Air "Moist air")));
   parameter Integer nPorts=0 "Number of fluid ports" annotation (Evaluate=true,
       Dialog(
       connectorSizing=true,


### PR DESCRIPTION
I added an annotation in `IBPSA.ThermalZones.ISO13790.Zone5R1C.ZoneHVAC` to allow the selection of medium. In this case, only Moist Air is available. 