### PR TITLE
Updated documentation of Examples package

### DIFF
--- a/IBPSA/Examples/package.mo
+++ b/IBPSA/Examples/package.mo
@@ -3,9 +3,20 @@ package Examples "Collection of models that illustrate model use and test models
   extends Modelica.Icons.ExamplesPackage;
 annotation (preferredView="info", Documentation(info="<html>
 <p>
-This package contains examples for the use of models that can be found in
-<a href=\"modelica://IBPSA\">
-IBPSA</a>.
+This package contains examples and tutorials with step-by-step instructions
+for how to build system models.
+</p>
+<p>
+The examples illustrate
+the scope of the library. Smaller examples that typically only
+use models from a few packages can be found in the individual packages.
+For example, see
+<a href=\"modelica://Buildings.Airflow.Multizone.Examples\">
+Buildings.Airflow.Multizone.Examples</a> for examples of
+multizone airflow and contaminant transport models, or
+<a href=\"modelica://IBPSA.Fluid.HeatExchangers.Examples\">
+IBPSA.Fluid.HeatExchangers.Examples</a> for
+examples of heat exchanger models.
 </p>
 </html>"));
 end Examples;


### PR DESCRIPTION
This adds more information to the top-level documentation of IBPSA.Examples.
The changes have been made so we can automatically merge IBPSA to Buildings without overriding the documentation that Buildings had, and which was not added when we integrated the `Tutorial` into the IBPSA library.