### PR TITLE
Removed all 'kW' declarations

### DIFF
--- a/IBPSA/Fluid/HeatPumps/ModularReversible/BaseClasses/PartialModularRefrigerantCycle.mo
+++ b/IBPSA/Fluid/HeatPumps/ModularReversible/BaseClasses/PartialModularRefrigerantCycle.mo
@@ -10,26 +10,26 @@ partial model PartialModularRefrigerantCycle
         transformation(extent={{-18,84},{18,116}}), iconTransformation(extent={{-16,84},
             {18,114}})));
   Modelica.Blocks.Interfaces.RealOutput QCon_flow(
-    final unit="W", displayUnit="kW")
+    final unit="W")
     "Heat flow rate from the refrigerant to the condenser medium"
     annotation (Placement(transformation(extent={{100,-10},{120,10}})));
   Modelica.Blocks.Interfaces.RealOutput QEva_flow(
-    final unit="W", displayUnit="kW")
+    final unit="W")
     "Heat flow rate from the evaporator medium to the refrigerant"
     annotation (Placement(transformation(extent={{-100,-10},{-120,10}})));
   Modelica.Blocks.Logical.Switch swiQEva(
-    u1(final unit="W", displayUnit="kW"),
-    u3(final unit="W", displayUnit="kW"),
-    y(final unit="W", displayUnit="kW")) if use_rev
+    u1(final unit="W"),
+    u3(final unit="W"),
+    y(final unit="W")) if use_rev
     "Routing block that picks the component acting as evaporator"
     annotation (Placement(transformation(extent={{-60,-10},{-80,10}})));
   Modelica.Blocks.Logical.Switch swiQCon(
-    y(final unit="W", displayUnit="kW"),
-    u1(final unit="W", displayUnit="kW"),
-    u3(final unit="W", displayUnit="kW")) if use_rev
+    y(final unit="W"),
+    u1(final unit="W"),
+    u3(final unit="W")) if use_rev
     "Routing block that picks the component acting as condenser"
     annotation (Placement(transformation(extent={{60,-10},{80,10}})));
-  Modelica.Blocks.Interfaces.RealOutput PEle(final unit="W", displayUnit="kW")
+  Modelica.Blocks.Interfaces.RealOutput PEle(final unit="W")
     "Routing block that picks the component for electric power consumption"
     annotation (Placement(
         transformation(
@@ -38,9 +38,9 @@ partial model PartialModularRefrigerantCycle
         origin={0.5,-110.5})));
 
   Modelica.Blocks.Logical.Switch swiPEle(
-    u1(final unit="W", displayUnit="kW"),
-    u3(final unit="W", displayUnit="kW"),
-    y(final unit="W", displayUnit="kW")) if use_rev
+    u1(final unit="W"),
+    u3(final unit="W"),
+    y(final unit="W")) if use_rev
     "Whether to use cooling or heating power output" annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},

--- a/IBPSA/Fluid/HeatPumps/ModularReversible/RefrigerantCycle/BaseClasses/PartialRefrigerantCycle.mo
+++ b/IBPSA/Fluid/HeatPumps/ModularReversible/RefrigerantCycle/BaseClasses/PartialRefrigerantCycle.mo
@@ -47,13 +47,13 @@ partial model PartialRefrigerantCycle
   parameter Modelica.Units.SI.SpecificHeatCapacity cpEva
     "Evaporator medium specific heat capacity"
     annotation (Dialog(tab="Advanced", group="Medium properties"));
-  Modelica.Blocks.Interfaces.RealOutput PEle(final unit="W", displayUnit="kW")
+  Modelica.Blocks.Interfaces.RealOutput PEle(final unit="W")
     "Electrical Power consumed by the device" annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=270,
         origin={0,-130})));
-  Modelica.Blocks.Interfaces.RealOutput QCon_flow(final unit="W", displayUnit="kW")
+  Modelica.Blocks.Interfaces.RealOutput QCon_flow(final unit="W")
   "Heat flow rate through condenser" annotation (
       Placement(transformation(
         extent={{-10,-10},{10,10}},
@@ -64,7 +64,7 @@ partial model PartialRefrigerantCycle
         extent={{-15,-14},{15,14}},
         rotation=0,
         origin={1,120})));
-  Modelica.Blocks.Interfaces.RealOutput QEva_flow(final unit="W", displayUnit="kW")
+  Modelica.Blocks.Interfaces.RealOutput QEva_flow(final unit="W")
     "Heat flow rate through evaporator" annotation (
       Placement(transformation(
         extent={{-10,-10},{10,10}},

--- a/IBPSA/Fluid/HeatPumps/ModularReversible/RefrigerantCycle/BaseClasses/PartialTableData2D.mo
+++ b/IBPSA/Fluid/HeatPumps/ModularReversible/RefrigerantCycle/BaseClasses/PartialTableData2D.mo
@@ -19,7 +19,7 @@ partial model PartialTableData2D
     final smoothness=smoothness,
     final u1(unit="K", displayUnit="degC"),
     final u2(unit="K", displayUnit="degC"),
-    final y(unit="W", displayUnit="kW"),
+    final y(unit="W"),
     final extrapolation=extrapolation) "Electrical power consumption table" annotation (
       Placement(transformation(
         extent={{-10,-10},{10,10}},
@@ -33,7 +33,7 @@ partial model PartialTableData2D
     final smoothness=smoothness,
     final u1(unit="K", displayUnit="degC"),
     final u2(unit="K", displayUnit="degC"),
-    final y(unit="W", displayUnit="kW"),
+    final y(unit="W"),
     final extrapolation=extrapolation) "Table for useful heat flow rate"
                                        annotation (Placement(transformation(
           extent={{-10,-10},{10,10}}, rotation=-90,

--- a/IBPSA/Fluid/HeatPumps/ModularReversible/Validation/BaseClasses/PartialValidation.mo
+++ b/IBPSA/Fluid/HeatPumps/ModularReversible/Validation/BaseClasses/PartialValidation.mo
@@ -100,10 +100,10 @@ partial model PartialValidation
   Modelica.Blocks.Interfaces.RealOutput TEvaOutMea(unit="K", displayUnit="degC")
     "Measured evaporator outlet"
     annotation (Placement(transformation(extent={{100,0},{120,20}})));
-  Modelica.Blocks.Interfaces.RealOutput PEleMea(unit="W", displayUnit="kW")
+  Modelica.Blocks.Interfaces.RealOutput PEleMea(unit="W")
     "Measured electrical power consumption"
     annotation (Placement(transformation(extent={{100,-78},{120,-58}})));
-  Modelica.Blocks.Interfaces.RealOutput PEleSim(unit="W", displayUnit="kW")
+  Modelica.Blocks.Interfaces.RealOutput PEleSim(unit="W")
     "Simulated electrical power consumption"
     annotation (Placement(transformation(extent={{100,-102},{120,-82}})));
   Modelica.Blocks.Interfaces.RealOutput TConOutSim(unit="K", displayUnit="degC")


### PR DESCRIPTION
They have been removed as no other model sets `kW`. In Dymola and IMPACT, users could change all `W` to `kW` if they want to, in which case the setting is applied to all quantities with `W`, not just the ones declared here.

@FWuellhorst : If you agree please merge it to the development branch.