### PR TITLE
Corrected typo in annotation

### DIFF
--- a/IBPSA/Fluid/FMI/Conversion/AirToOutlet.mo
+++ b/IBPSA/Fluid/FMI/Conversion/AirToOutlet.mo
@@ -48,7 +48,7 @@ block AirToOutlet
     if allowFlowReversal
     "Temperature of the backward flowing medium in the connector outlet"
     annotation (Placement(
-        visible=allowFloWReserval,
+        visible=allowFlowReversal,
         transformation(extent={{20,20},{-20,-20}},
         rotation=90,
         origin={-60,-120}),
@@ -61,7 +61,7 @@ block AirToOutlet
     if Medium.nXi > 0 and allowFlowReversal
     "Water mass fraction per total air mass of the backward flowing medium in the connector outlet"
     annotation (Placement(
-        visible=allowFloWReserval,
+        visible=allowFlowReversal,
         transformation(extent={{20,20},{-20,-20}},
         rotation=90,
         origin={0,-120}),
@@ -74,7 +74,7 @@ block AirToOutlet
     if allowFlowReversal
     "Trace substances of the backward flowing medium in the connector outlet"
     annotation (Placement(
-        visible=allowFloWReserval,
+        visible=allowFlowReversal,
         transformation(extent={{20,20},{-20,-20}},
         rotation=90,
         origin={60,-120}),

--- a/IBPSA/Fluid/FMI/Conversion/InletToAir.mo
+++ b/IBPSA/Fluid/FMI/Conversion/InletToAir.mo
@@ -24,7 +24,7 @@ block InletToAir
     if allowFlowReversal
     "Zone air temperature"
     annotation (Placement(
-        visible=allowFloWReserval,
+        visible=allowFlowReversal,
         transformation(extent={{-20,-20},{20,20}},
         rotation=90,
         origin={-60,-120}),
@@ -37,7 +37,7 @@ block InletToAir
     if Medium.nXi > 0 and allowFlowReversal
     "Zone air water mass fraction per total air mass"
     annotation (Placement(
-        visible=allowFloWReserval,
+        visible=allowFlowReversal,
         transformation(extent={{-20,-20},{20,20}},
         rotation=90,
         origin={0,-120}),
@@ -50,7 +50,7 @@ block InletToAir
     if allowFlowReversal
     "Zone air trace substances"
     annotation (Placement(
-        visible=allowFloWReserval,
+        visible=allowFlowReversal,
         transformation(extent={{-20,-20},{20,20}},
         rotation=90,
         origin={60,-120}),


### PR DESCRIPTION
This corrects a typo in the visible annotation that causes a warning in Dymola when saving the file