### PR TITLE
Added missing causality

### DIFF
--- a/IBPSA/Fluid/FMI/Adaptors/Inlet.mo
+++ b/IBPSA/Fluid/FMI/Adaptors/Inlet.mo
@@ -35,14 +35,14 @@ model Inlet "Adaptor for connecting a fluid inlet to the FMI interface"
         rotation=270,
         origin={0,-110})));
 protected
-  IBPSA.Fluid.FMI.Interfaces.FluidProperties bacPro_internal(
+  input IBPSA.Fluid.FMI.Interfaces.FluidProperties bacPro_internal(
     redeclare final package Medium = Medium)
     "Internal connector for fluid properties for back flow";
   IBPSA.Fluid.FMI.Interfaces.PressureOutput p_in_internal
     "Internal connector for pressure";
-  IBPSA.Fluid.FMI.Interfaces.MassFractionConnector X_w_in_internal
+  output IBPSA.Fluid.FMI.Interfaces.MassFractionConnector X_w_in_internal
     "Internal connector for mass fraction of forward flow properties";
-  IBPSA.Fluid.FMI.Interfaces.MassFractionConnector X_w_out_internal
+  output IBPSA.Fluid.FMI.Interfaces.MassFractionConnector X_w_out_internal
     "Internal connector for mass fraction of backward flow properties";
 initial equation
    assert(Medium.nXi < 2,
@@ -169,6 +169,11 @@ for how to use this model.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 18, 2024, by Michael Wetter:<br/>
+Added causality.<br/>
+See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1853\">#1853</a>.
+</li>
 <li>
 January 18, 2019, by Jianjun Hu:<br/>
 Limited the media choice to moist air and water.

--- a/IBPSA/Fluid/FMI/Adaptors/Inlet.mo
+++ b/IBPSA/Fluid/FMI/Adaptors/Inlet.mo
@@ -172,7 +172,7 @@ for how to use this model.
 <li>
 March 18, 2024, by Michael Wetter:<br/>
 Added causality.<br/>
-See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1853\">#1853</a>.
+See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1853\">IBPSA, #1853</a>.
 </li>
 <li>
 January 18, 2019, by Jianjun Hu:<br/>

--- a/IBPSA/Fluid/FMI/Adaptors/Outlet.mo
+++ b/IBPSA/Fluid/FMI/Adaptors/Outlet.mo
@@ -36,15 +36,15 @@ model Outlet "Adaptor for connecting a fluid outlet to the FMI interface"
         rotation=90,
         origin={0,-120})));
 protected
-  IBPSA.Fluid.FMI.Interfaces.FluidProperties bacPro_internal(
+  output IBPSA.Fluid.FMI.Interfaces.FluidProperties bacPro_internal(
     redeclare final package Medium = Medium)
     "Internal connector for fluid properties for back flow";
   IBPSA.Fluid.FMI.Interfaces.PressureOutput p_in_internal
     "Internal connector for pressure";
 
-  IBPSA.Fluid.FMI.Interfaces.MassFractionConnector X_w_in_internal
+  input IBPSA.Fluid.FMI.Interfaces.MassFractionConnector X_w_in_internal
     "Internal connector for mass fraction of forward flow properties";
-  IBPSA.Fluid.FMI.Interfaces.MassFractionConnector X_w_out_internal
+  output IBPSA.Fluid.FMI.Interfaces.MassFractionConnector X_w_out_internal
     "Internal connector for mass fraction of backward flow properties";
 initial equation
    assert(Medium.nXi < 2,
@@ -152,6 +152,11 @@ for how to use this model.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 18, 2024, by Michael Wetter:<br/>
+Added causality.<br/>
+See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1853\">#1853</a>.
+</li>
 <li>
 June 29, 2023, by Michael Wetter:<br/>
 Corrected dimension of <code>X</code> in function call.<br/>

--- a/IBPSA/Fluid/FMI/Adaptors/Outlet.mo
+++ b/IBPSA/Fluid/FMI/Adaptors/Outlet.mo
@@ -155,7 +155,7 @@ for how to use this model.
 <li>
 March 18, 2024, by Michael Wetter:<br/>
 Added causality.<br/>
-See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1853\">#1853</a>.
+See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1853\">IBPSA, #1853</a>.
 </li>
 <li>
 June 29, 2023, by Michael Wetter:<br/>

--- a/IBPSA/Fluid/FMI/FlowSplitter_u.mo
+++ b/IBPSA/Fluid/FMI/FlowSplitter_u.mo
@@ -147,7 +147,7 @@ the model stops with an error.
 <li>
 March 18, 2024, by Michael Wetter:<br/>
 Added causality.<br/>
-See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1853\">#1853</a>.
+See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1853\">IBPSA, #1853</a>.
 </li>
 <li>
 January 18, 2019, by Jianjun Hu:<br/>

--- a/IBPSA/Fluid/FMI/FlowSplitter_u.mo
+++ b/IBPSA/Fluid/FMI/FlowSplitter_u.mo
@@ -44,10 +44,10 @@ protected
   final parameter Modelica.Units.SI.MassFlowRate mAve_flow_nominal=sum(
       m_flow_nominal)/nout "Average nominal mass flow rate";
 protected
-  IBPSA.Fluid.FMI.Interfaces.FluidProperties bacPro_internal(
+  input IBPSA.Fluid.FMI.Interfaces.FluidProperties bacPro_internal(
     redeclare final package Medium = Medium)
     "Internal connector for fluid properties for back flow";
-  IBPSA.Fluid.FMI.Interfaces.MassFractionConnector X_w_out_internal = 0
+  output IBPSA.Fluid.FMI.Interfaces.MassFractionConnector X_w_out_internal = 0
     "Internal connector for mass fraction of backward flow properties";
 
 initial equation
@@ -144,6 +144,11 @@ the model stops with an error.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 18, 2024, by Michael Wetter:<br/>
+Added causality.<br/>
+See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1853\">#1853</a>.
+</li>
 <li>
 January 18, 2019, by Jianjun Hu:<br/>
 Limited the media choice.

--- a/IBPSA/Fluid/FMI/Sink_T.mo
+++ b/IBPSA/Fluid/FMI/Sink_T.mo
@@ -117,7 +117,7 @@ may be needed to iteratively solve for the mass flow rate.
 <li>
 March 18, 2024, by Michael Wetter:<br/>
 Added causality.<br/>
-See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1853\">#1853</a>.
+See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1853\">IBPSA, #1853</a>.
 </li>
 <li>
 January 18, 2019, by Jianjun Hu:<br/>

--- a/IBPSA/Fluid/FMI/Sink_T.mo
+++ b/IBPSA/Fluid/FMI/Sink_T.mo
@@ -46,7 +46,7 @@ model Sink_T
         rotation=180,
         origin={-120,-80})));
 protected
-  IBPSA.Fluid.FMI.Interfaces.FluidProperties bacPro_internal(
+  input IBPSA.Fluid.FMI.Interfaces.FluidProperties bacPro_internal(
     redeclare final package Medium = Medium)
     "Internal connector for fluid properties for back flow";
   IBPSA.Fluid.FMI.Interfaces.PressureOutput p_in_internal
@@ -114,6 +114,11 @@ may be needed to iteratively solve for the mass flow rate.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 18, 2024, by Michael Wetter:<br/>
+Added causality.<br/>
+See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1853\">#1853</a>.
+</li>
 <li>
 January 18, 2019, by Jianjun Hu:<br/>
 Limited the media choice to moist air and water.

--- a/IBPSA/Fluid/FMI/Source_T.mo
+++ b/IBPSA/Fluid/FMI/Source_T.mo
@@ -47,7 +47,7 @@ model Source_T
 protected
   IBPSA.Fluid.FMI.Interfaces.PressureOutput p_in_internal
     "Internal connector for pressure";
-  IBPSA.Fluid.FMI.Interfaces.MassFractionConnector X_w_in_internal
+  input IBPSA.Fluid.FMI.Interfaces.MassFractionConnector X_w_in_internal
     "Internal connector for mass fraction of forward flow properties";
 initial equation
    assert(Medium.nXi < 2,
@@ -101,6 +101,11 @@ and the mass flow rate of the system.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 18, 2024, by Michael Wetter:<br/>
+Added causality.<br/>
+See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1853\">#1853</a>.
+</li>
 <li>
 January 18, 2019, by Jianjun Hu:<br/>
 Limited the media choice to moist air only.

--- a/IBPSA/Fluid/FMI/Source_T.mo
+++ b/IBPSA/Fluid/FMI/Source_T.mo
@@ -104,7 +104,7 @@ and the mass flow rate of the system.
 <li>
 March 18, 2024, by Michael Wetter:<br/>
 Added causality.<br/>
-See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1853\">#1853</a>.
+See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1853\">IBPSA, #1853</a>.
 </li>
 <li>
 January 18, 2019, by Jianjun Hu:<br/>

--- a/IBPSA/Resources/ReferenceResults/Dymola/IBPSA_Fluid_FMI_ExportContainers_Examples_FMUs_FlowSplitter_u.txt
+++ b/IBPSA/Resources/ReferenceResults/Dymola/IBPSA_Fluid_FMI_ExportContainers_Examples_FMUs_FlowSplitter_u.txt
@@ -1,63 +1,65 @@
-last-generated=2016-12-22
+last-generated=2024-03-21
 statistics-fmu-dependencies=
 {
-  "Outputs": {
-    "outlet[1].m_flow": [
-      "u[1]"
-    ], 
-    "outlet[1].p": [
-      "inlet.p"
-    ], 
-    "outlet[2].forward.T": [
-      "inlet.forward.T"
-    ], 
-    "inlet.backward.T": [], 
-    "outlet[1].forward.T": [
-      "inlet.forward.T"
-    ], 
-    "outlet[2].m_flow": [
-      "u[2]"
-    ], 
-    "inlet.backward.X_w": [], 
-    "outlet[1].forward.X_w": [
-      "inlet.forward.X_w"
-    ], 
-    "outlet[2].p": [
-      "inlet.p"
-    ], 
-    "outlet[2].forward.X_w": [
-      "inlet.forward.X_w"
-    ]
-  }, 
+  "Derivatives": {},
   "InitialUnknowns": {
-    "outlet[1].m_flow": [
-      "m_flow_nominal[1]", 
-      "u[1]"
-    ], 
-    "outlet[1].p": [
-      "inlet.p"
-    ], 
-    "outlet[2].forward.T": [
-      "inlet.forward.T"
-    ], 
-    "inlet.backward.T": [], 
+    "X_w_out_internal": [],
+    "inlet.backward.T": [],
+    "inlet.backward.X_w": [],
     "outlet[1].forward.T": [
       "inlet.forward.T"
-    ], 
-    "outlet[2].m_flow": [
-      "m_flow_nominal[2]", 
-      "u[2]"
-    ], 
-    "inlet.backward.X_w": [], 
+    ],
     "outlet[1].forward.X_w": [
       "inlet.forward.X_w"
-    ], 
-    "outlet[2].p": [
+    ],
+    "outlet[1].m_flow": [
+      "m_flow_nominal[1]",
+      "u[1]"
+    ],
+    "outlet[1].p": [
       "inlet.p"
-    ], 
+    ],
+    "outlet[2].forward.T": [
+      "inlet.forward.T"
+    ],
     "outlet[2].forward.X_w": [
       "inlet.forward.X_w"
+    ],
+    "outlet[2].m_flow": [
+      "m_flow_nominal[2]",
+      "u[2]"
+    ],
+    "outlet[2].p": [
+      "inlet.p"
     ]
-  }, 
-  "Derivatives": {}
+  },
+  "Outputs": {
+    "X_w_out_internal": [],
+    "inlet.backward.T": [],
+    "inlet.backward.X_w": [],
+    "outlet[1].forward.T": [
+      "inlet.forward.T"
+    ],
+    "outlet[1].forward.X_w": [
+      "inlet.forward.X_w"
+    ],
+    "outlet[1].m_flow": [
+      "u[1]"
+    ],
+    "outlet[1].p": [
+      "inlet.p"
+    ],
+    "outlet[2].forward.T": [
+      "inlet.forward.T"
+    ],
+    "outlet[2].forward.X_w": [
+      "inlet.forward.X_w"
+    ],
+    "outlet[2].m_flow": [
+      "u[2]"
+    ],
+    "outlet[2].p": [
+      "inlet.p"
+    ]
+  }
 }


### PR DESCRIPTION
This closes #1853

This adds more missing `input` and `output` prefixes, similarly to https://github.com/ibpsa/modelica-ibpsa/pull/1835