### PR TITLE
Changed sensor configuration to avoid warning

### DIFF
--- a/IBPSA/Airflow/Multizone/Examples/CO2TransportStep.mo
+++ b/IBPSA/Airflow/Multizone/Examples/CO2TransportStep.mo
@@ -5,13 +5,19 @@ model CO2TransportStep "Model with transport of CO2 through buoyancy driven flow
     volTop(nPorts=3),
     volEas(nPorts=6));
 
-  IBPSA.Fluid.Sensors.TraceSubstances CO2SenTop(redeclare package Medium = Medium)
+  IBPSA.Fluid.Sensors.TraceSubstances CO2SenTop(
+    redeclare package Medium = Medium,
+    warnAboutOnePortConnection = false)
     "CO2 sensor"
     annotation (Placement(transformation(extent={{20,120},{40,140}})));
-  IBPSA.Fluid.Sensors.TraceSubstances CO2SenWes(redeclare package Medium = Medium)
+  IBPSA.Fluid.Sensors.TraceSubstances CO2SenWes(
+    redeclare package Medium = Medium,
+    warnAboutOnePortConnection = false)
     "CO2 sensor"
     annotation (Placement(transformation(extent={{-102,10},{-82,30}})));
-  IBPSA.Fluid.Sensors.TraceSubstances CO2SenEas(redeclare package Medium = Medium)
+  IBPSA.Fluid.Sensors.TraceSubstances CO2SenEas(
+    redeclare package Medium = Medium,
+    warnAboutOnePortConnection = false)
     "CO2 sensor"
     annotation (Placement(transformation(extent={{58,10},{78,30}})));
   Modelica.Blocks.Sources.Pulse pulse(
@@ -64,6 +70,12 @@ the other rooms, and eventually its concentration decays.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 26, 2024, by Michael Wetter:<br/>
+Configured the sensor parameter to suppress the warning about being a one-port connection.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1857\">IBPSA, #1857</a>.
+</li>
 <li>
 March 26, 2021 by Michael Wetter:<br/>
 Updated comments for

--- a/IBPSA/Fluid/Sensors/Conversions/Examples/To_VolumeFraction.mo
+++ b/IBPSA/Fluid/Sensors/Conversions/Examples/To_VolumeFraction.mo
@@ -16,8 +16,10 @@ model To_VolumeFraction "Example problem for conversion model"
     k=2,
     Td=1)
     annotation (Placement(transformation(extent={{-100,-20},{-80,0}})));
-  IBPSA.Fluid.Sensors.TraceSubstances senCO2(redeclare package Medium =
-        Medium, substanceName="CO2") "CO2 sensor"
+  IBPSA.Fluid.Sensors.TraceSubstances senCO2(
+    redeclare package Medium = Medium,
+    substanceName="CO2",
+    warnAboutOnePortConnection = false) "CO2 sensor"
     annotation (Placement(transformation(extent={{120,0},{140,20}})));
   IBPSA.Fluid.MixingVolumes.MixingVolume vol(
     nPorts=4,
@@ -152,6 +154,12 @@ Note that for simplicity, we allow zero outside air flow rate if the CO<sub>2</s
 the setpoint, which does not comply with ASHRAE regulations.
 </html>", revisions="<html>
 <ul>
+<li>
+March 26, 2024, by Michael Wetter:<br/>
+Configured the sensor parameter to suppress the warning about being a one-port connection.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1857\">IBPSA, #1857</a>.
+</li>
 <li>
 May 2, 2019, by Jianjun Hu:<br/>
 Replaced fluid source. This is for

--- a/IBPSA/Fluid/Sources/Examples/TraceSubstancesFlowSource.mo
+++ b/IBPSA/Fluid/Sources/Examples/TraceSubstancesFlowSource.mo
@@ -11,11 +11,13 @@ model TraceSubstancesFlowSource
     energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial) "Mixing volume"
                           annotation (Placement(transformation(extent={{100,120},
             {120,140}})));
-  Sources.TraceSubstancesFlowSource sou(redeclare package Medium = Medium,
-      use_m_flow_in=true,
+  Sources.TraceSubstancesFlowSource sou(
+    redeclare package Medium = Medium,
+    use_m_flow_in=true,
     nPorts=1)
     annotation (Placement(transformation(extent={{-46,110},{-26,130}})));
-  Modelica.Blocks.Sources.Step step(          startTime=0.5,
+  Modelica.Blocks.Sources.Step step(
+    startTime=0.5,
     height=-2,
     offset=2)
     annotation (Placement(transformation(extent={{-92,30},{-72,50}})));
@@ -106,16 +108,24 @@ model TraceSubstancesFlowSource
     "Resistance, used to check if species are transported between ports"
     annotation (Placement(transformation(extent={{-28,-80},{-6,-60}})));
 
-  Sensors.TraceSubstances C(redeclare package Medium = Medium)
+  Sensors.TraceSubstances C(
+    redeclare package Medium = Medium,
+    warnAboutOnePortConnection = false)
     "Trace substance sensor"
     annotation (Placement(transformation(extent={{120,134},{140,154}})));
-  Sensors.TraceSubstances C1(redeclare package Medium = Medium)
+  Sensors.TraceSubstances C1(
+    redeclare package Medium = Medium,
+    warnAboutOnePortConnection = false)
     "Trace substance sensor"
     annotation (Placement(transformation(extent={{120,90},{140,110}})));
-  Sensors.TraceSubstances C2(redeclare package Medium = Medium)
+  Sensors.TraceSubstances C2(
+    redeclare package Medium = Medium,
+    warnAboutOnePortConnection = false)
     "Trace substance sensor"
     annotation (Placement(transformation(extent={{168,6},{188,26}})));
-  Sensors.TraceSubstances C3(redeclare package Medium = Medium)
+  Sensors.TraceSubstances C3(
+    redeclare package Medium = Medium,
+    warnAboutOnePortConnection = false)
     "Trace substance sensor"
     annotation (Placement(transformation(extent={{188,-50},{208,-30}})));
   FixedResistances.PressureDrop res4(
@@ -254,6 +264,12 @@ The sensors
 as there is a mass flow rate with zero CO<sub>2</sub> from the source <code>bou</code> to the sink <code>sin</code>.
 </html>", revisions="<html>
 <ul>
+<li>
+March 26, 2024, by Michael Wetter:<br/>
+Configured the sensor parameter to suppress the warning about being a one-port connection.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1857\">IBPSA, #1857</a>.
+</li>
 <li>
 November 27, 2013 by Michael Wetter:<br/>
 Added pressure boundary condition to model.

--- a/IBPSA/ThermalZones/ReducedOrder/Validation/RoomWithLatentGain.mo
+++ b/IBPSA/ThermalZones/ReducedOrder/Validation/RoomWithLatentGain.mo
@@ -14,11 +14,13 @@ model RoomWithLatentGain
       startTime3=0,
       endTime3=0));
   Fluid.Sensors.RelativeHumidity senRelHum(
-    redeclare package Medium = Medium)
+    redeclare package Medium = Medium,
+    warnAboutOnePortConnection = false)
     "Relative humidity of room air"
     annotation (Placement(transformation(extent={{110,-20},{130,0}})));
   Fluid.Sensors.MassFraction senMasFra(
-    redeclare package Medium = Medium)
+    redeclare package Medium = Medium,
+    warnAboutOnePortConnection = false)
     "Absolute humidity of room air in kg/kg total air"
     annotation (Placement(transformation(extent={{110,-50},{130,-30}})));
 equation
@@ -38,6 +40,12 @@ This test case changes the medium to moist air, and adds latent heat gain.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 26, 2024, by Michael Wetter:<br/>
+Configured the sensor parameter to suppress the warning about being a one-port connection.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1857\">IBPSA, #1857</a>.
+</li>
 <li>
 October 9, 2019, by Michael Wetter:<br/>
 First implementation.<br/>

--- a/IBPSA/ThermalZones/ReducedOrder/Validation/RoomWithoutLatentGain.mo
+++ b/IBPSA/ThermalZones/ReducedOrder/Validation/RoomWithoutLatentGain.mo
@@ -21,11 +21,13 @@ model RoomWithoutLatentGain
     rotation=0,
     origin={23,3})));
   Fluid.Sensors.RelativeHumidity senRelHum(
-    redeclare package Medium = Medium)
+    redeclare package Medium = Medium,
+    warnAboutOnePortConnection = false)
     "Relative humidity of room air"
     annotation (Placement(transformation(extent={{110,-20},{130,0}})));
   Fluid.Sensors.MassFraction senMasFra(
-    redeclare package Medium = Medium)
+    redeclare package Medium = Medium,
+    warnAboutOnePortConnection = false)
     "Absolute humidity of room air in kg/kg total air"
     annotation (Placement(transformation(extent={{110,-50},{130,-30}})));
 equation
@@ -45,6 +47,12 @@ This test case changes the medium to moist air, and adds zero latent heat gain.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 26, 2024, by Michael Wetter:<br/>
+Configured the sensor parameter to suppress the warning about being a one-port connection.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1857\">IBPSA, #1857</a>.
+</li>
 <li>
 October 9, 2019, by Michael Wetter:<br/>
 First implementation.<br/>


### PR DESCRIPTION
This configures the sensor so that no warning is issued due to one port connection, as this type of connection is fine for these examples.

This closes #1857