### PR TITLE
issue1878 mover model warnings

### DIFF
--- a/IBPSA/Fluid/FMI/ExportContainers/Examples/FMUs/Fan.mo
+++ b/IBPSA/Fluid/FMI/ExportContainers/Examples/FMUs/Fan.mo
@@ -3,6 +3,7 @@ block Fan "Declaration of an FMU that exports a fan"
    extends IBPSA.Fluid.FMI.ExportContainers.ReplaceableTwoPort(
      redeclare replaceable package Medium =  IBPSA.Media.Air,
      redeclare final Movers.FlowControlled_dp com(
+      nominalValuesDefineDefaultPressureCurve=true,
       final m_flow_nominal=m_flow_nominal,
       final use_inputFilter=
                           false,
@@ -43,6 +44,13 @@ IBPSA.Fluid.Movers.FlowControlled_m_flow</a>.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+April 9, 2024, by Hongxiang Fu:<br/>
+Specified <code>nominalValuesDefineDefaultPressureCurve=true</code>
+in the mover component to suppress a warning.
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3819\">#3819</a>.
+</li>
 <li>
 January 22, 2016, by Michael Wetter:<br/>
 Corrected type declaration of pressure difference.

--- a/IBPSA/Fluid/FMI/ExportContainers/Examples/FMUs/HVACZones.mo
+++ b/IBPSA/Fluid/FMI/ExportContainers/Examples/FMUs/HVACZones.mo
@@ -64,6 +64,7 @@ block HVACZones
     annotation (Placement(transformation(extent={{100,-100},{120,-80}})));
   Movers.FlowControlled_m_flow fan(
     redeclare package Medium = MediumA,
+    nominalValuesDefineDefaultPressureCurve=true,
     m_flow_nominal=mA_flow_nominal,
     energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
     allowFlowReversal=allowFlowReversal) "Supply air fan"
@@ -162,6 +163,7 @@ block HVACZones
     redeclare package Medium = MediumA,
     energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
     allowFlowReversal=allowFlowReversal,
+    nominalValuesDefineDefaultPressureCurve=true,
     m_flow_nominal=mA_flow_nominal/10,
     inputType=IBPSA.Fluid.Types.InputType.Constant)
     "Supply air fan that extracts a constant amount of outside air"
@@ -328,6 +330,13 @@ ports which are exposed at the FMU interface.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+April 9, 2024, by Hongxiang Fu:<br/>
+Specified <code>nominalValuesDefineDefaultPressureCurve=true</code>
+in the mover component to suppress a warning.
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3819\">#3819</a>.
+</li>
 <li>
 September 21, 2021 by David Blum:<br/>
 Correct supply and return water parameterization.<br/>

--- a/IBPSA/Fluid/Geothermal/Borefields/Examples/RectangularBorefield.mo
+++ b/IBPSA/Fluid/Geothermal/Borefields/Examples/RectangularBorefield.mo
@@ -73,6 +73,7 @@ model RectangularBorefield "Example model of a rectangular borefield"
   IBPSA.Fluid.Movers.FlowControlled_m_flow pum(
     redeclare package Medium = Medium,
     addPowerToMedium=false,
+    nominalValuesDefineDefaultPressureCurve=true,
     use_inputFilter=false,
     energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
     inputType=IBPSA.Fluid.Types.InputType.Constant,
@@ -119,6 +120,13 @@ where <code>dBorHol</code> is the distance between the boreholes,
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+April 9, 2024, by Hongxiang Fu:<br/>
+Specified <code>nominalValuesDefineDefaultPressureCurve=true</code>
+in the mover component to suppress a warning.
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3819\">#3819</a>.
+</li>
 <li>
 September 10, 2018, by Michael Wetter:<br/>
 First implementation.

--- a/IBPSA/Fluid/Movers/Data/Generic.mo
+++ b/IBPSA/Fluid/Movers/Data/Generic.mo
@@ -29,12 +29,14 @@ record Generic "Generic data record for movers"
 
   // Efficiency computation choices
   parameter IBPSA.Fluid.Movers.BaseClasses.Types.HydraulicEfficiencyMethod etaHydMet=
-    IBPSA.Fluid.Movers.BaseClasses.Types.HydraulicEfficiencyMethod.EulerNumber
+    if havePressureCurve
+    then IBPSA.Fluid.Movers.BaseClasses.Types.HydraulicEfficiencyMethod.EulerNumber
+    else IBPSA.Fluid.Movers.BaseClasses.Types.HydraulicEfficiencyMethod.NotProvided
     "Efficiency computation method for the hydraulic efficiency etaHyd"
     annotation (Dialog(group="Power computation"));
   parameter IBPSA.Fluid.Movers.BaseClasses.Types.MotorEfficiencyMethod etaMotMet=
-    if powerOrEfficiencyIsHydraulic
-      then IBPSA.Fluid.Movers.BaseClasses.Types.MotorEfficiencyMethod.GenericCurve
+    if powerOrEfficiencyIsHydraulic and havePressureCurve
+    then IBPSA.Fluid.Movers.BaseClasses.Types.MotorEfficiencyMethod.GenericCurve
     else IBPSA.Fluid.Movers.BaseClasses.Types.MotorEfficiencyMethod.NotProvided
     "Efficiency computation method for the motor efficiency etaMot"
     annotation (Dialog(group="Power computation"));
@@ -158,6 +160,12 @@ record Generic "Generic data record for movers"
   defaultComponentName = "per",
   Documentation(revisions="<html>
 <ul>
+<li>
+April 8, 2024, by Hongxiang Fu:<br/>
+Default efficiency methods now depend on whether a pressure curve is available.
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3819\">#3819</a>.
+</li>
 <li>
 March 29, 2023, by Hongxiang Fu:<br/>
 Deleted angular speed parameters with the unit rpm.

--- a/IBPSA/Fluid/Movers/Examples/MoverParameter.mo
+++ b/IBPSA/Fluid/Movers/Examples/MoverParameter.mo
@@ -9,6 +9,7 @@ model MoverParameter
 
   IBPSA.Fluid.Movers.FlowControlled_m_flow pump_m_flow(
     redeclare package Medium = Medium,
+    nominalValuesDefineDefaultPressureCurve=true,
     m_flow_nominal=m_flow_nominal,
     use_inputFilter=false,
     massFlowRates={0,0.5,1}*m_flow_nominal,
@@ -87,6 +88,13 @@ set point for a mover model.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+April 8, 2024, by Hongxiang Fu:<br/>
+Specified <code>nominalValuesDefineDefaultPressureCurve=true</code>
+in the mover component to suppress a warning.
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3819\">#3819</a>.
+</li>
 <li>
 March 21, 2023, by Hongxiang Fu:<br/>
 Deleted the mover with <code>Nrpm</code> signal.

--- a/IBPSA/Fluid/Movers/Validation/FlowControlled_dp.mo
+++ b/IBPSA/Fluid/Movers/Validation/FlowControlled_dp.mo
@@ -4,11 +4,13 @@ model FlowControlled_dp "Fan with zero mass flow rate and head as input"
  extends IBPSA.Fluid.Movers.Validation.BaseClasses.FlowMachine_ZeroFlow(
     gain(k=dp_nominal),
     redeclare IBPSA.Fluid.Movers.FlowControlled_dp floMacSta(
+      nominalValuesDefineDefaultPressureCurve=true,
       redeclare package Medium = Medium,
       m_flow_nominal=m_flow_nominal,
       use_inputFilter=false,
       energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState),
     redeclare IBPSA.Fluid.Movers.FlowControlled_dp floMacDyn(
+      nominalValuesDefineDefaultPressureCurve=true,
       redeclare package Medium = Medium,
       m_flow_nominal=m_flow_nominal,
       use_inputFilter=false,
@@ -37,6 +39,13 @@ This ensures that the actual speed is equal to the input signal.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+April 8, 2024, by Hongxiang Fu:<br/>
+Specified <code>nominalValuesDefineDefaultPressureCurve=true</code>
+in the mover component to suppress a warning.
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3819\">#3819</a>.
+</li>
 <li>
 November 5, 2015, by Michael Wetter:<br/>
 Changed parameters of fan since the power is no longer a parameter.

--- a/IBPSA/Fluid/Movers/Validation/FlowControlled_dpSystem.mo
+++ b/IBPSA/Fluid/Movers/Validation/FlowControlled_dpSystem.mo
@@ -23,6 +23,7 @@ model FlowControlled_dpSystem
     redeclare package Medium = Medium,
     energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
     allowFlowReversal=false,
+    nominalValuesDefineDefaultPressureCurve=true,
     m_flow_nominal=1,
     use_inputFilter=false) "Regular dp controlled fan"
     annotation (Placement(transformation(extent={{-80,50},{-60,70}})));
@@ -30,6 +31,7 @@ model FlowControlled_dpSystem
     redeclare package Medium = Medium,
     energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
     allowFlowReversal=false,
+    nominalValuesDefineDefaultPressureCurve=true,
     m_flow_nominal=1,
     use_inputFilter=false,
     prescribeSystemPressure=true)
@@ -227,6 +229,13 @@ The mass flow rates and actual pressure heads of the two configurations are comp
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+April 9, 2024, by Hongxiang Fu:<br/>
+Specified <code>nominalValuesDefineDefaultPressureCurve=true</code>
+in the mover component to suppress a warning.
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3819\">#3819</a>.
+</li>
 <li>
 May 4 2017, by Filip Jorissen:<br/>
 First implementation.

--- a/IBPSA/Fluid/Movers/Validation/FlowControlled_m_flow.mo
+++ b/IBPSA/Fluid/Movers/Validation/FlowControlled_m_flow.mo
@@ -5,11 +5,13 @@ model FlowControlled_m_flow
  extends IBPSA.Fluid.Movers.Validation.BaseClasses.FlowMachine_ZeroFlow(
     gain(k=m_flow_nominal),
     redeclare IBPSA.Fluid.Movers.FlowControlled_m_flow floMacSta(
+      nominalValuesDefineDefaultPressureCurve=true,
       redeclare package Medium = Medium,
       m_flow_nominal=m_flow_nominal,
       use_inputFilter=false,
       energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState),
     redeclare IBPSA.Fluid.Movers.FlowControlled_m_flow floMacDyn(
+      nominalValuesDefineDefaultPressureCurve=true,
       redeclare package Medium = Medium,
       m_flow_nominal=m_flow_nominal,
       use_inputFilter=false,
@@ -38,6 +40,13 @@ This ensures that the actual speed is equal to the input signal.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+April 8, 2024, by Hongxiang Fu:<br/>
+Specified <code>nominalValuesDefineDefaultPressureCurve=true</code>
+in the mover component to suppress a warning.
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3819\">#3819</a>.
+</li>
 <li>
 February 14, 2012, by Michael Wetter:<br/>
 Added filter for start-up and shut-down transient.

--- a/IBPSA/Fluid/Movers/Validation/PumpCurveDerivatives.mo
+++ b/IBPSA/Fluid/Movers/Validation/PumpCurveDerivatives.mo
@@ -41,6 +41,7 @@ model PumpCurveDerivatives
 
   IBPSA.Fluid.Movers.FlowControlled_m_flow forcedPump1(
     redeclare package Medium = Medium,
+    nominalValuesDefineDefaultPressureCurve=true,
     m_flow_nominal=3,
     energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState,
     use_inputFilter=false) "Pump for forcing a certain mass flow rate"
@@ -153,6 +154,13 @@ monotoneously increasing or decreasing relations between <code>dp</code>,
 </html>",
 revisions="<html>
 <ul>
+<li>
+April 8, 2024, by Hongxiang Fu:<br/>
+Specified <code>nominalValuesDefineDefaultPressureCurve=true</code>
+in the mover component to suppress a warning.
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3819\">#3819</a>.
+</li>
 <li>
 March 21, 2023, by Hongxiang Fu:<br/>
 Replaced the pump with <code>Nrpm</code> signal with one with <code>y</code>

--- a/IBPSA/Fluid/Movers/Validation/Pump_y_stratos.mo
+++ b/IBPSA/Fluid/Movers/Validation/Pump_y_stratos.mo
@@ -54,28 +54,38 @@ model Pump_y_stratos "Model validation using a Wilo Stratos 80/1-12 pump"
     per=per) "Wilo Stratos pump"
     annotation (Placement(transformation(extent={{-60,-130},{-40,-110}})));
 
-  IBPSA.Fluid.Movers.FlowControlled_m_flow forcedPump1(redeclare package
-      Medium = Medium, m_flow_nominal=3,
+  IBPSA.Fluid.Movers.FlowControlled_m_flow forcedPump1(
+    redeclare package Medium = Medium,
+    nominalValuesDefineDefaultPressureCurve=true,
+    m_flow_nominal=3,
     energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState)
     "Pump for forcing a certain mass flow rate"
     annotation (Placement(transformation(extent={{38,60},{58,80}})));
-  IBPSA.Fluid.Movers.FlowControlled_m_flow forcedPump2(redeclare package
-      Medium = Medium, m_flow_nominal=3,
+  IBPSA.Fluid.Movers.FlowControlled_m_flow forcedPump2(
+    redeclare package Medium = Medium,
+    nominalValuesDefineDefaultPressureCurve=true,
+    m_flow_nominal=3,
     energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState)
     "Pump for forcing a certain mass flow rate"
     annotation (Placement(transformation(extent={{38,10},{58,30}})));
-  IBPSA.Fluid.Movers.FlowControlled_m_flow forcedPump3(redeclare package
-      Medium = Medium, m_flow_nominal=3,
+  IBPSA.Fluid.Movers.FlowControlled_m_flow forcedPump3(
+    redeclare package Medium = Medium,
+    nominalValuesDefineDefaultPressureCurve=true,
+    m_flow_nominal=3,
     energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState)
     "Pump for forcing a certain mass flow rate"
     annotation (Placement(transformation(extent={{38,-36},{58,-16}})));
-  IBPSA.Fluid.Movers.FlowControlled_m_flow forcedPump4(redeclare package
-      Medium = Medium, m_flow_nominal=3,
+  IBPSA.Fluid.Movers.FlowControlled_m_flow forcedPump4(
+    redeclare package Medium = Medium,
+    nominalValuesDefineDefaultPressureCurve=true,
+    m_flow_nominal=3,
     energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState)
     "Pump for forcing a certain mass flow rate"
     annotation (Placement(transformation(extent={{38,-80},{58,-60}})));
-  IBPSA.Fluid.Movers.FlowControlled_m_flow forcedPump5(redeclare package
-      Medium = Medium, m_flow_nominal=3,
+  IBPSA.Fluid.Movers.FlowControlled_m_flow forcedPump5(
+    redeclare package Medium = Medium,
+    nominalValuesDefineDefaultPressureCurve=true,
+    m_flow_nominal=3,
     energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState)
     "Pump for forcing a certain mass flow rate"
     annotation (Placement(transformation(extent={{38,-130},{58,-110}})));
@@ -261,6 +271,13 @@ Wilo Stratos 80/1-12 data sheet</a>.
 </html>",
 revisions="<html>
 <ul>
+<li>
+April 8, 2024, by Hongxiang Fu:<br/>
+Specified <code>nominalValuesDefineDefaultPressureCurve=true</code>
+in the mover component to suppress a warning.
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3819\">#3819</a>.
+</li>
 <li>
 March 21, 2023, by Hongxiang Fu:<br/>
 Replaced the pumps with <code>Nrpm</code> signal with ones with <code>y</code>


### PR DESCRIPTION
This closes #1878.
This PR merges changes made in https://github.com/lbl-srg/modelica-buildings/pull/3830 that are applicable to IBPSA.

> Models in the `Obsolete` package are skipped.
> The following models are also skipped because they are planned to be obsoleted in a separate issue: `Fluid.Movers.Validation.{PowerEuler,PowerExact,PowerSimplified}`.