### PR TITLE
Update documentation for borefield models

### DIFF
--- a/IBPSA/Fluid/Geothermal/Borefields/UsersGuide.mo
+++ b/IBPSA/Fluid/Geothermal/Borefields/UsersGuide.mo
@@ -17,7 +17,7 @@ IBPSA.Fluid.Geothermal.Borefields.Validation</a>,
 respectively.
 </p>
 <p>
-The major features and configurations currently supported are:
+The following major features and configurations are supported:
 <ul>
 <li> User-defined borefield characteristics and geometry (borehole radius, pipe radius, shank spacing, etc.),
 including single U-tube, double U-tube in parallel and double U-tube in series configurations.


### PR DESCRIPTION
This updates the documentation for the borefield models.
The change is mainly to remove the "currently" as it implies that changes will be done to the model.