### PR TITLE
Changed markup commands in heat pump base class

### DIFF
--- a/IBPSA/Fluid/HeatPumps/ModularReversible/BaseClasses/PartialReversibleRefrigerantMachine.mo
+++ b/IBPSA/Fluid/HeatPumps/ModularReversible/BaseClasses/PartialReversibleRefrigerantMachine.mo
@@ -382,9 +382,9 @@ partial model PartialReversibleRefrigerantMachine
         rotation=180,
         origin={110,30})));
 // To avoid using the bus, set the section below to protected
-// <!-- @include_Buildings @include_IDEAS @include_BuildingSystems
+//@modelica_select_start @remove_AixLib
 protected
-// -->
+//@modelica_select_end
   RefrigerantMachineControlBus sigBus
     "Bus with model outputs and possibly inputs" annotation (Placement(transformation(
           extent={{-156,-58},{-126,-24}}),iconTransformation(extent={{-108,-52},
@@ -393,12 +393,12 @@ protected
   parameter Boolean use_busConOnl=false
     "=true to allow input to bus connector,
     not applicable with internal safety control"
-    annotation(choices(checkBox=true), Dialog(group="Input Connectors", enable=not
-          use_intSafCtr));
+    annotation(choices(checkBox=true),
+                Dialog(group="Input Connectors", enable=not use_intSafCtr));
 
-// <!-- @include_AixLib
+//@modelica_select_start @remove_Buildings @remove_BuildingSystems @remove_IDEAS
 protected
-// -->
+//@modelica_select_end
   parameter Boolean use_COP "=true to enable COP output";
   parameter Boolean use_EER "=true to enable EER output";
   parameter MediumCon.ThermodynamicState staCon_nominal=MediumCon.setState_pTX(
@@ -692,6 +692,12 @@ equation
           fillPattern=FillPattern.Solid)}),
        Diagram(coordinateSystem(extent={{-140,-160},{140,160}})),
     Documentation(revisions="<html><ul>
+  <li>
+    <i>August 19, 2024</i> by Michael Wetter:<br/>
+    Changed markup commands for code merge.<br/>
+    This is for
+    <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1919\">IBPSA #1919</a>.
+  </li>
   <li>
     <i>July 15, 2024</i> by Fabian Wuellhorst:<br/>
     Adjust hysteresis bandwidth (see issue


### PR DESCRIPTION
This is to allow use of the refactored BuildingsPy, see https://github.com/lbl-srg/BuildingsPy/issues/566
that properly adds/removes code for AixLib. Other libraries worked already, and won't change the behavior due to this PR.

This closes #1919