### PR TITLE
Issue1927 ref cyc update

### DIFF
--- a/IBPSA/Fluid/Chillers/ModularReversible/RefrigerantCycle/ConstantCarnotEffectiveness.mo
+++ b/IBPSA/Fluid/Chillers/ModularReversible/RefrigerantCycle/ConstantCarnotEffectiveness.mo
@@ -18,7 +18,8 @@ model ConstantCarnotEffectiveness "Carnot EER with a constant Carnot effectivene
     min=0,
     final unit="1") = etaCarnot_nominal*(TEva_nominal - TAppEva_nominal)/(
     TCon_nominal + TAppCon_nominal - (TEva_nominal - TAppEva_nominal))
-    "Nominal EER";
+    "Nominal EER"
+    annotation(Dialog(group="Nominal condition"));
 
   Modelica.Blocks.Sources.Constant constNegOne(final k=-1)
     "Negative one to negative evaporator heat flow rate" annotation (Placement(

--- a/IBPSA/Fluid/HeatPumps/ModularReversible/BaseClasses/PartialReversibleRefrigerantMachine.mo
+++ b/IBPSA/Fluid/HeatPumps/ModularReversible/BaseClasses/PartialReversibleRefrigerantMachine.mo
@@ -39,6 +39,19 @@ partial model PartialReversibleRefrigerantMachine
     "if use_rev=true, device data for cooling and heating need to entered. Set allowDifferentDeviceIdentifiers=true to allow different device identifiers devIde"
     annotation(Dialog(tab="Advanced", enable=use_rev));
 
+  // Safety control
+  parameter Boolean use_intSafCtr=true
+    "=true to enable internal safety control"
+    annotation (Dialog(group="Safety control"), choices(checkBox=true));
+  replaceable parameter
+    IBPSA.Fluid.HeatPumps.ModularReversible.Controls.Safety.Data.Wuellhorst2021 safCtrPar
+    constrainedby
+    IBPSA.Fluid.HeatPumps.ModularReversible.Controls.Safety.Data.Generic
+    "Safety control parameters" annotation (Dialog(enable=use_intSafCtr,
+    group="Safety control"),
+      choicesAllMatching=true,
+      Placement(transformation(extent={{42,-18},{58,-2}})));
+
   //Condenser
   parameter Modelica.Units.SI.Time tauCon=30
     "Condenser heat transfer time constant at nominal flow"
@@ -129,20 +142,6 @@ partial model PartialReversibleRefrigerantMachine
   final parameter Modelica.Units.SI.SpecificHeatCapacity cpEva=
       MediumEva.specificHeatCapacityCp(staEva_nominal)
     "Evaporator medium specific heat capacity";
-
-  // Safety control
-  parameter Boolean use_intSafCtr=true
-    "=true to enable internal safety control"
-    annotation (Dialog(group="Safety control"), choices(checkBox=true));
-  replaceable parameter
-    IBPSA.Fluid.HeatPumps.ModularReversible.Controls.Safety.Data.Wuellhorst2021 safCtrPar
-    constrainedby
-    IBPSA.Fluid.HeatPumps.ModularReversible.Controls.Safety.Data.Generic
-    "Safety control parameters" annotation (Dialog(enable=use_intSafCtr,
-    group="Safety control"),
-      choicesAllMatching=true,
-      Placement(transformation(extent={{42,-18},{58,-2}})));
-
 
 //Assumptions
   parameter Boolean allowFlowReversalEva=true

--- a/IBPSA/Fluid/HeatPumps/ModularReversible/RefrigerantCycle/BaseClasses/PartialCarnot.mo
+++ b/IBPSA/Fluid/HeatPumps/ModularReversible/RefrigerantCycle/BaseClasses/PartialCarnot.mo
@@ -2,9 +2,11 @@ within IBPSA.Fluid.HeatPumps.ModularReversible.RefrigerantCycle.BaseClasses;
 partial model PartialCarnot
   "Model with components for Carnot efficiency calculation"
   parameter Boolean useForChi "=false to use in heat pump models";
-  parameter Real etaCarnot_nominal=0.3 "Constant Carnot effectiveness";
+  parameter Real etaCarnot_nominal=0.3 "Constant Carnot effectiveness"
+    annotation(Dialog(group="Nominal condition"));
   parameter Boolean use_constAppTem=false
-    "=true to fix approach temperatures at nominal values. This can improve simulation speed";
+    "=true to fix approach temperatures at nominal values. This can improve simulation speed"
+    annotation(Dialog(group="Efficiency"));
   parameter Modelica.Units.SI.TemperatureDifference TAppCon_nominal(min=0)
     "Temperature difference between refrigerant and working fluid outlet in condenser"
     annotation (Dialog(group="Efficiency"));

--- a/IBPSA/Fluid/HeatPumps/ModularReversible/RefrigerantCycle/BaseClasses/PartialHeatPumpCycle.mo
+++ b/IBPSA/Fluid/HeatPumps/ModularReversible/RefrigerantCycle/BaseClasses/PartialHeatPumpCycle.mo
@@ -11,7 +11,7 @@ partial model PartialHeatPumpCycle
     "Calculates evaporator heat flow with total energy balance" annotation (
       Placement(transformation(extent={{-80,-20},{-60,0}}, rotation=0)));
 equation
-  connect(iceFacCal.iceFac, sigBus.icefacHPMea) annotation (Line(points={{-81.2,
+  connect(iceFacCal.iceFac, sigBus.iceFacHPMea) annotation (Line(points={{-81.2,
           -50},{-64,-50},{-64,-28},{-110,-28},{-110,120},{1,120}},
                                                               color={0,0,127}),
       Text(

--- a/IBPSA/Fluid/HeatPumps/ModularReversible/RefrigerantCycle/BaseClasses/PartialTableData2D.mo
+++ b/IBPSA/Fluid/HeatPumps/ModularReversible/RefrigerantCycle/BaseClasses/PartialTableData2D.mo
@@ -10,10 +10,12 @@ partial model PartialTableData2D
     annotation (Dialog(group="Nominal condition"));
   parameter Modelica.Blocks.Types.Smoothness smoothness=
     Modelica.Blocks.Types.Smoothness.LinearSegments
-    "Smoothness of table interpolation";
+    "Smoothness of table interpolation"
+    annotation(Dialog(group="Data handling"));
   parameter Modelica.Blocks.Types.Extrapolation extrapolation=
     Modelica.Blocks.Types.Extrapolation.LastTwoPoints
-    "Extrapolation of data outside the definition range";
+    "Extrapolation of data outside the definition range"
+    annotation(Dialog(group="Data handling"));
   parameter Boolean use_TEvaOutForTab=true
     "=true to use evaporator outlet temperature, false for inlet";
   parameter Boolean use_TConOutForTab=true

--- a/IBPSA/Fluid/HeatPumps/ModularReversible/RefrigerantCycle/ConstantCarnotEffectiveness.mo
+++ b/IBPSA/Fluid/HeatPumps/ModularReversible/RefrigerantCycle/ConstantCarnotEffectiveness.mo
@@ -17,7 +17,8 @@ model ConstantCarnotEffectiveness "Carnot COP with a constant Carnot effectivene
     min=0,
     final unit="1") = etaCarnot_nominal*(TCon_nominal + TAppCon_nominal)/(
     TCon_nominal + TAppCon_nominal - (TEva_nominal - TAppEva_nominal))
-    "Nominal coefficient of performance";
+    "Nominal coefficient of performance"
+    annotation(Dialog(group="Nominal condition"));
 equation
 
   connect(pasThrYMea.u, sigBus.yMea) annotation (Line(points={{18,70},{0,70},{0,


### PR DESCRIPTION
This closes #1927 and fixes a typo in the `iceFac` of the heating operation of a heat pump. I opted against moving the `RefrigerantCycleInertia` into the Dynamics tab as it may not only be used for dynamics (I model start-stop losses with this block) and is an important setting as the underlying data is steady state.