### PR TITLE
Use max pressure for state if flow reversal allowed for airflow models

### DIFF
--- a/IBPSA/Airflow/Multizone/BaseClasses/PartialOneWayFlowElement.mo
+++ b/IBPSA/Airflow/Multizone/BaseClasses/PartialOneWayFlowElement.mo
@@ -57,7 +57,7 @@ equation
   else
     sta = if homotopyInitialization then
         Medium.setState_phX(
-          port_a.p,
+          if allowFlowReversal then max(port_a.p,port_b.p) else port_a.p,
           homotopy(
             actual=actualStream(port_a.h_outflow),
             simplified=inStream(port_a.h_outflow)),
@@ -66,7 +66,7 @@ equation
             simplified=inStream(port_a.Xi_outflow)))
       else
         Medium.setState_phX(
-          port_a.p,
+          if allowFlowReversal then max(port_a.p,port_b.p) else port_a.p,
           actualStream(port_a.h_outflow),
           actualStream(port_a.Xi_outflow));
 


### PR DESCRIPTION
Updated the pressure input to Medium.setState_phX to use the maximum of port_a.p and port_b.p when allowFlowReversal is true. This ensures more correct state calculation during flow reversal scenarios. In the door models, the flow is allready calculated based on actual rho (direction-dependent).