### PR TITLE
Issue2035 disable pressure loss in plug flow pipe

### DIFF
--- a/IBPSA/Fluid/FixedResistances/PlugFlowPipe.mo
+++ b/IBPSA/Fluid/FixedResistances/PlugFlowPipe.mo
@@ -10,9 +10,14 @@ model PlugFlowPipe
       final fac=fac,
       final ReC=ReC,
       final v_nominal=v_nominal,
+      final disableComputeFlowResistance=disableComputeFlowResistance,
       final homotopyInitialization=homotopyInitialization,
       final linearized=linearized,
     dp(nominal=fac*200*length)));
+
+  parameter Boolean disableComputeFlowResistance=false
+    "=false to disable computation of flow resistance"
+    annotation (Dialog(tab="Advanced"));
 
   annotation (
     Line(points={{70,20},{72,20},{72,0},{100,0}}, color={0,127,255}),
@@ -61,6 +66,11 @@ model PlugFlowPipe
           textString="L = %length")}),
     Documentation(revisions="<html>
 <ul>
+<li>
+July 29, 2025, by Fabian Wuelhorst:<br/>
+Add option to <code>disableComputeFlowResistance</code>.<br/>
+See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/2035\">#2035</a>.
+</li>
 <li>
 October 05, 2021, by Baptiste Ravache:<br/>
 Made model symmetrical and extends from

--- a/IBPSA/Fluid/FixedResistances/PlugFlowPipeDiscretized.mo
+++ b/IBPSA/Fluid/FixedResistances/PlugFlowPipeDiscretized.mo
@@ -77,6 +77,9 @@ model PlugFlowPipeDiscretized
   parameter Boolean linearized = false
     "= true, use linear relation between m_flow and dp for any flow rate"
     annotation(Evaluate=true, Dialog(tab="Advanced"));
+  parameter Boolean disableComputeFlowResistance=false
+    "=false to disable computation of flow resistance"
+    annotation (Dialog(tab="Advanced"));
 
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heatPorts[nSeg]
     "Heat transfer to or from surrounding for each pipe segment (positive if pipe is colder than surrounding)"
@@ -108,6 +111,7 @@ model PlugFlowPipeDiscretized
     final v_nominal=v_nominal,
     final allowFlowReversal=allowFlowReversal,
     final show_T=false,
+    final disableComputeFlowResistance=disableComputeFlowResistance,
     final homotopyInitialization=homotopyInitialization,
     final linearized=linearized,
     dp(nominal= if rho_default > 500 then totLen * fac * 200 else totLen * fac * 2))
@@ -250,6 +254,11 @@ equation
           thickness=0.5)}),
     Documentation(revisions="<html>
 <ul>
+<li>
+July 29, 2025, by Fabian Wuelhorst:<br/>
+Add option to <code>disableComputeFlowResistance</code>.<br/>
+See <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/2035\">#2035</a>.
+</li>
 <li>
 May 17, 2021, by Baptiste Ravache:<br/>
 First implementation.


### PR DESCRIPTION
Closes #2035.

I opted to add the parameter to `BaseClasses.PlugFlowPipe`, as the `res` is constrained by partial two port, which does not have the parameter. Not sure if others use this base class except the two models in IBPSA. If so, we could avoid redeclaration, set `disableComputeFlowResistance=true` in `IBPSA.Fluid.FixedResistances.PlugFlowPipeDiscretized` and aggregate the single values in one standard pressure drop.
