### PR TITLE
Update travis image to Ubuntu 24.04 and Python 3.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 os: Linux
-dist: focal
+dist: nobel
 
 language: python
 
 python:
-  - "3.8"
+  - "3.12"
 
 cache: pip
 
@@ -55,8 +55,6 @@ before_install:
 
 # Install dependencies
 install:
-  - pip3 install --upgrade pip wheel
-  - pip3 install --only-binary=numpy,scipy,matplotlib numpy==1.21.4 scipy==1.7.3 matplotlib==3.5.1
   - pip3 install git+https://github.com/lbl-srg/${BUILDINGSPY_VERSION}
 
 # Execute tests


### PR DESCRIPTION
This closes #2058.

It also updates Python and removes non-needed pip commands that caused version incompatibility.