### PR TITLE
Fix OS and distribution names in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-os: Linux
-dist: nobel
+os: linux
+dist: noble
 
 language: python
 


### PR DESCRIPTION
This corrects the OS name and the distribution name. See https://github.com/lbl-srg/modelica-buildings/issues/4428